### PR TITLE
Expand Registration Functionality (PAYINP-687)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2020-12-20
+### Added
+- A new `RegistrationRequestService` class which can build the request for client registration with an ASPSP
+### Changed
+- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument, 
+  instead of the already signed claims, and does the signing itself 
+- The `registerClient` method in `RegistrationClient` now returns the registration response body as a data object with
+  dedicated fields for the data, instead of a plain string
+- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport 
+  certificate to use for an ASPSP
+- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when 
+  registering as a client with an ASPSP
+- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for 
+  building a client registration request. 
+
 ## [0.0.27] - 2020-12-18
 - Improvements to the Gradle publishing process
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @transferwise/cards
+*   @transferwise/payin-platform

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Java client for using the Open Banking API, exposed by an ASPSP, as a TPP. The library supports a subset of the full 
 API:  
 
-- Support for registering as a TPP client with an ASPSP
+- Support for version 3 [dynamic client registration](https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html)
 - Support for version 3 [single immediate domestic payments](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/937984109/Domestic+Payments+v3.1)
 - Support for the following OAuth client authentication methods
     - Mutual TLS
@@ -34,7 +34,9 @@ RestTemplate restTemplate = new RestTemplate();
 KeySupplier signingKeySupplier = new ExampleKeySupplier();
 JwtClaimsSigner jwtClaimsSigner = new JwtClaimsSigner(signingKeySupplier, tppConfiguration);
 
-RegistrationClient registrationClient = new RestRegistrationClient(restTemplate);
+RegistrationClient registrationClient = new RestRegistrationClient(jwtClaimsSigner, restTemplate);
+
+RegistrationRequestService registrationRequestService = new RegistrationRequestService(keySupplier, tppConfiguration);
 
 // supplies the details of the ASPSP implementation required to make the API calls
 AspspDetails aspspDetails = new ExampleAspspDetails();
@@ -43,11 +45,12 @@ AspspDetails aspspDetails = new ExampleAspspDetails();
 // Step 2 - register with the ASPSP
 // 
 
-// set the properties according to your organisation and the ASPSP
-JwtClaims registrationClaims = new JwtClaims();
-String signedClaims = jwtClaimsSigner.createSignature(registrationClaims, aspspDetails);
+ClientRegistrationRequest clientRegistrationRequest = registrationRequestService.generateRegistrationRequest(
+        softwareStatement, 
+        aspspDetails);
 
-String registrationResponseBody = registrationClient.registerClient(signedClaims, aspspDetails);
+ClientRegistrationResponse clientRegistrationResponse = registrationClient.registerClient(clientRegistrationRequest, 
+        aspspDetails);
 ```
 
 ### V3 Payments

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     testImplementation("org.springframework:spring-test:${libs.spring}")
 
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.67")
+
+    testImplementation("ch.qos.logback:logback-classic:1.2.3")
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.27
+version=1.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
@@ -1,5 +1,7 @@
 package com.transferwise.openbanking.client.api.registration;
 
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 
 /**
@@ -10,12 +12,13 @@ public interface RegistrationClient {
     /**
      * Register as a TPP client with an ASPSP.
      *
-     * @param signedClaims The details (JWT claims) of the registration request, signed with the TPP's signing key
+     * @param clientRegistrationRequest The details (JWT claims) of the registration request
      * @param aspspDetails The details of the ASPSP to send the request to
-     * @return The complete response body from the ASPSP, containing the details of the registration
+     * @return The response body from the ASPSP, containing the details of the registration
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
      *                                                                   failed
      */
-    String registerClient(String signedClaims, AspspDetails aspspDetails);
+    ClientRegistrationResponse registerClient(ClientRegistrationRequest clientRegistrationRequest,
+                                              AspspDetails aspspDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -1,0 +1,97 @@
+package com.transferwise.openbanking.client.api.registration;
+
+import com.transferwise.openbanking.client.api.registration.domain.ApplicationType;
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
+import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.TppConfiguration;
+import com.transferwise.openbanking.client.error.ClientException;
+import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
+import com.transferwise.openbanking.client.security.KeySupplier;
+import lombok.RequiredArgsConstructor;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class RegistrationRequestService {
+
+    private static final long REGISTRATION_TOKEN_VALIDITY_SECONDS = 300;
+
+    private final KeySupplier keySupplier;
+    private final TppConfiguration tppConfiguration;
+
+    public ClientRegistrationRequest generateRegistrationRequest(String softwareStatement, AspspDetails aspspDetails) {
+        Instant now = Instant.now();
+
+        ClientAuthenticationMethod clientAuthenticationMethod = aspspDetails.getClientAuthenticationMethod();
+        String signingAlgorithm = aspspDetails.getSigningAlgorithm();
+
+        ClientRegistrationRequest.ClientRegistrationRequestBuilder requestBuilder = ClientRegistrationRequest.builder()
+            .iss(tppConfiguration.getSoftwareStatementId())
+            .aud(aspspDetails.getRegistrationIssuerUrl())
+            .iat(now.getEpochSecond())
+            .exp(now.plusSeconds(REGISTRATION_TOKEN_VALIDITY_SECONDS).getEpochSecond())
+            .jti(generateJwtIdValue(aspspDetails))
+            .applicationType(ApplicationType.WEB)
+            .scope(generateScopeValue())
+            .softwareId(tppConfiguration.getSoftwareStatementId())
+            .softwareStatement(softwareStatement)
+            .grantTypes(aspspDetails.getGrantTypes())
+            .responseTypes(aspspDetails.getResponseTypes())
+            .tokenEndpointAuthMethod(clientAuthenticationMethod.getMethodName())
+            .idTokenSignedResponseAlg(signingAlgorithm)
+            .requestObjectSigningAlg(signingAlgorithm)
+            .redirectUris(List.of(tppConfiguration.getRedirectUrl()));
+
+        if (ClientAuthenticationMethod.TLS_CLIENT_AUTH == clientAuthenticationMethod) {
+            requestBuilder.tlsClientAuthSubjectDn(getTransportCertificateSubjectName(aspspDetails));
+        }
+
+        if (ClientAuthenticationMethod.PRIVATE_KEY_JWT == clientAuthenticationMethod) {
+            requestBuilder.tokenEndpointAuthSigningAlg(signingAlgorithm);
+        }
+
+        return requestBuilder.build();
+    }
+
+    private String generateJwtIdValue(AspspDetails aspspDetails) {
+        String jti = UUID.randomUUID().toString();
+        if (aspspDetails.registrationRequiresLowerCaseJtiClaim()) {
+            return jti.toLowerCase();
+        } else {
+            return jti.toUpperCase();
+        }
+    }
+
+    private String generateScopeValue() {
+        List<RegistrationPermission> permissions;
+        // registration requests always have to include the OPENID permission
+        if (tppConfiguration.getPermissions().contains(RegistrationPermission.OPENID)) {
+            permissions = tppConfiguration.getPermissions();
+        } else {
+            permissions = new ArrayList<>();
+            permissions.add(RegistrationPermission.OPENID);
+            permissions.addAll(tppConfiguration.getPermissions());
+        }
+
+        return permissions.stream()
+            .map(RegistrationPermission::getValue)
+            .collect(Collectors.joining(" "));
+    }
+
+    private String getTransportCertificateSubjectName(AspspDetails aspspDetails) {
+        Certificate transportCertificate = keySupplier.getTransportCertificate(aspspDetails);
+        if (transportCertificate instanceof X509Certificate) {
+            return ((X509Certificate) transportCertificate).getSubjectX500Principal().getName();
+        } else {
+            throw new ClientException("Supplied transport certificate is not an X509 certificate, cannot determine " +
+                "transport certificate subject name");
+        }
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -1,8 +1,12 @@
 package com.transferwise.openbanking.client.api.registration;
 
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
+import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -13,15 +17,18 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestOperations;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.List;
 
 @RequiredArgsConstructor
+@Slf4j
 public class RestRegistrationClient implements RegistrationClient {
 
+    private final JwtClaimsSigner jwtClaimsSigner;
     private final RestOperations restTemplate;
 
     @Override
-    public String registerClient(String signedClaims, AspspDetails aspspDetails) {
+    public ClientRegistrationResponse registerClient(ClientRegistrationRequest clientRegistrationRequest,
+                                                     AspspDetails aspspDetails) {
 
         HttpHeaders headers = new HttpHeaders();
         if (aspspDetails.registrationUsesJoseContentType()) {
@@ -29,19 +36,29 @@ public class RestRegistrationClient implements RegistrationClient {
         } else {
             headers.setContentType(MediaType.valueOf("application/jwt"));
         }
-        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         // as we're using a raw String as the body type, we need to manually set the header
-        headers.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+        headers.setAcceptCharset(List.of(StandardCharsets.UTF_8));
 
+        String signedClaims = jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails);
         HttpEntity<String> request = new HttpEntity<>(signedClaims, headers);
 
+        log.debug("Sending registration request to '{}' with headers '{}' and body '{}'",
+            aspspDetails.getRegistrationUrl(),
+            request.getHeaders(),
+            request.getBody());
+
         try {
-            // TODO: use a proper object as the response, not just a raw string
-            ResponseEntity<String> response = restTemplate.exchange(
+            ResponseEntity<ClientRegistrationResponse> response = restTemplate.exchange(
                 aspspDetails.getRegistrationUrl(),
                 HttpMethod.POST,
                 request,
-                String.class);
+                ClientRegistrationResponse.class);
+
+            log.debug("Received registration response with headers '{}' and body '{}'",
+                response.getHeaders(),
+                response.getBody());
+
             return response.getBody();
         } catch (RestClientResponseException e) {
             throw new ApiCallException("Call to register client endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ApplicationType.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ApplicationType.java
@@ -1,0 +1,17 @@
+package com.transferwise.openbanking.client.api.registration.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ApplicationType {
+    WEB("web"),
+    MOBILE("mobile");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ClientRegistrationRequest.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ClientRegistrationRequest.java
@@ -1,0 +1,59 @@
+package com.transferwise.openbanking.client.api.registration.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.transferwise.openbanking.client.oauth.domain.GrantType;
+import com.transferwise.openbanking.client.oauth.domain.ResponseType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * Data structure for the request to an ASPSP for the dynamic client registration endpoint.
+ *
+ * @see <a href="https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html#obclientregistrationrequest1">API docs</a>
+ */
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ClientRegistrationRequest {
+
+    private String iss;
+
+    private Long iat;
+
+    private Long exp;
+
+    private String aud;
+
+    private String jti;
+
+    private String clientId;
+
+    private List<String> redirectUris;
+
+    private String tokenEndpointAuthMethod;
+
+    private List<GrantType> grantTypes;
+
+    private List<ResponseType> responseTypes;
+
+    private String softwareId;
+
+    private String scope;
+
+    private String softwareStatement;
+
+    private ApplicationType applicationType;
+
+    private String idTokenSignedResponseAlg;
+
+    private String requestObjectSigningAlg;
+
+    private String tokenEndpointAuthSigningAlg;
+
+    private String tlsClientAuthSubjectDn;
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ClientRegistrationResponse.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ClientRegistrationResponse.java
@@ -1,0 +1,59 @@
+package com.transferwise.openbanking.client.api.registration.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.transferwise.openbanking.client.oauth.domain.GrantType;
+import com.transferwise.openbanking.client.oauth.domain.ResponseType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Data structure for the response from an ASPSP for the dynamic client registration endpoint.
+ *
+ * @see <a href="https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html#obclientregistrationrequest1">API docs</a>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ClientRegistrationResponse {
+
+    private String clientId;
+
+    private String clientSecret;
+
+    private Integer clientIdIssuedAt;
+
+    private Integer clientSecretExpiresAt;
+
+    private List<String> redirectUris;
+
+    private String tokenEndpointAuthMethod;
+
+    private List<GrantType> grantTypes;
+
+    private List<ResponseType> responseTypes;
+
+    private String softwareId;
+
+    private String scope;
+
+    private String softwareStatement;
+
+    private ApplicationType applicationType;
+
+    private String idTokenSignedResponseAlg;
+
+    private String requestObjectSigningAlg;
+
+    private String tokenEndpointAuthSigningAlg;
+
+    private String tlsClientAuthSubjectDn;
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/domain/RegistrationPermission.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/domain/RegistrationPermission.java
@@ -1,0 +1,18 @@
+package com.transferwise.openbanking.client.api.registration.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum RegistrationPermission {
+    ACCOUNTS("accounts"),
+    PAYMENTS("payments"),
+    OPENID("openid");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -1,6 +1,11 @@
 package com.transferwise.openbanking.client.configuration;
 
+import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
+import com.transferwise.openbanking.client.oauth.domain.GrantType;
+import com.transferwise.openbanking.client.oauth.domain.ResponseType;
 import org.jose4j.jws.AlgorithmIdentifiers;
+
+import java.util.List;
 
 /**
  * Defines the integration details with a specific ASPSP.
@@ -49,12 +54,23 @@ public interface AspspDetails {
     /**
      * Get the URL the ASPSP exposes for registering this service as a client with the ASPSP.
      *
-     * <p>Not all banks support a registration API, therefore not all implementations implement this method.
+     * <p>Not all ASPSPs support a registration API, therefore not all implementations implement this method.
      *
      * @return the client registration URL
      */
     default String getRegistrationUrl() {
         throw new UnsupportedOperationException("getRegistrationUrl not implemented");
+    }
+
+    /**
+     * Get the URL to use as the intended audience value for a JWT generated for a client registration.
+     *
+     * <p>Not all ASPSPs support a registration API, therefore not all implementations implement this method.
+     *
+     * @return the JWT intended audience URL
+     */
+    default String getRegistrationIssuerUrl() {
+        throw new UnsupportedOperationException("getRegistrationIssuerUrl not implemented");
     }
 
     /**
@@ -69,6 +85,13 @@ public interface AspspDetails {
     default String getTokenIssuerUrl() {
         throw new UnsupportedOperationException("getTokenIssuerUrl not implemented");
     }
+
+    /**
+     * Get the authentication method to use for identifying ourselves as a client to the ASPSP.
+     *
+     * @return the client authentication method to use
+     */
+    ClientAuthenticationMethod getClientAuthenticationMethod();
 
     /**
      * Get the ID value to use for identifying ourselves as a client to the ASPSP.
@@ -113,6 +136,26 @@ public interface AspspDetails {
     String getSigningKeyId();
 
     /**
+     * Get the OAuth grant types, that the ASPSP supports and the TPP may request, to specify to the ASPSP during
+     * registration.
+     *
+     * @return the grant types to specify, defaults to all types
+     */
+    default List<GrantType> getGrantTypes() {
+        return List.of(GrantType.values());
+    }
+
+    /**
+     * Get the OAUth response types, that the ASPSP supports and the TPP may request, to specify to the ASPSP during
+     * registration.
+     *
+     * @return the response types to specify, defaults to all types
+     */
+    default List<ResponseType> getResponseTypes() {
+        return List.of(ResponseType.values());
+    }
+
+    /**
      * Get the minor version of the payments API that should be used when making calls to the ASPSP payments API.
      *
      * @return the payments API minor version to use, defaults to 1
@@ -150,5 +193,18 @@ public interface AspspDetails {
      */
     default boolean detachedSignatureUsesDirectoryIssFormat() {
         return true;
+    }
+
+    /**
+     * Whether or not the ASPSP requires the JWT ID (jti) claim, within client registration requests, to use only lower
+     * case characters.
+     *
+     * <p>This is false by default, as Version 3 of the registration API specifies it should be an uppercase v4 UUID,
+     * however some ASPSPs do not follow this requirement and instead require lowercase characters.
+     *
+     * @return <code>true</code> if the jti claim should contain only lowercase characters, <code>false</code> otherwise
+     */
+    default boolean registrationRequiresLowerCaseJtiClaim() {
+        return false;
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/configuration/TppConfiguration.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/TppConfiguration.java
@@ -1,9 +1,12 @@
 package com.transferwise.openbanking.client.configuration;
 
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @Builder
@@ -25,4 +28,10 @@ public class TppConfiguration {
      * The URL that ASPSPs will redirect the user back to once the authorisation process is finished.
      */
     private String redirectUrl;
+
+    /**
+     * The permissions that the TPP has, according to the National Competent Authority (the FCA), and wants to use when
+     * registering with an ASPSP.
+     */
+    private List<RegistrationPermission> permissions;
 }

--- a/src/main/java/com/transferwise/openbanking/client/jwt/JwtClaimsSigner.java
+++ b/src/main/java/com/transferwise/openbanking/client/jwt/JwtClaimsSigner.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.TppConfiguration;
 import com.transferwise.openbanking.client.error.ClientException;
+import com.transferwise.openbanking.client.security.KeySupplier;
 import lombok.RequiredArgsConstructor;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/GrantType.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/GrantType.java
@@ -1,0 +1,19 @@
+package com.transferwise.openbanking.client.oauth.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum GrantType {
+
+    AUTHORIZATION_CODE("authorization_code"),
+    CLIENT_CREDENTIALS("client_credentials"),
+    REFRESH_TOKEN("refresh_token");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/ResponseType.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/ResponseType.java
@@ -1,0 +1,18 @@
+package com.transferwise.openbanking.client.oauth.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ResponseType {
+
+    CODE("code"),
+    ID_TOKEN("id_token");
+
+    private final String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/security/KeySupplier.java
+++ b/src/main/java/com/transferwise/openbanking/client/security/KeySupplier.java
@@ -1,4 +1,4 @@
-package com.transferwise.openbanking.client.jwt;
+package com.transferwise.openbanking.client.security;
 
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 
@@ -26,4 +26,12 @@ public interface KeySupplier {
      * @return The signing certificate
      */
     Certificate getSigningCertificate(AspspDetails aspspDetails);
+
+    /**
+     * Get the certificate to use for the secure (TLS) connection to an ASPSP.
+     *
+     * @param aspspDetails The details of the ASPSP the connection will be made to
+     * @return The transport certificate
+     */
+    Certificate getTransportCertificate(AspspDetails aspspDetails);
 }

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
@@ -1,0 +1,172 @@
+package com.transferwise.openbanking.client.api.registration;
+
+import com.transferwise.openbanking.client.api.registration.domain.ApplicationType;
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
+import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.TppConfiguration;
+import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
+import com.transferwise.openbanking.client.oauth.domain.GrantType;
+import com.transferwise.openbanking.client.security.KeySupplier;
+import com.transferwise.openbanking.client.test.TestAspspDetails;
+import com.transferwise.openbanking.client.test.TestKeyUtils;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+class RegistrationRequestServiceTest {
+
+    private static final String JTI_UPPERCASE_REGEX =
+        "^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$";
+    private static final String JTI_LOWERCASE_REGEX =
+        "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
+
+    @Mock
+    private KeySupplier keySupplier;
+
+    private TppConfiguration tppConfiguration;
+
+    private RegistrationRequestService registrationRequestService;
+
+    @BeforeEach
+    void init() {
+        tppConfiguration = aTppConfiguration();
+
+        registrationRequestService = new RegistrationRequestService(keySupplier, tppConfiguration);
+    }
+
+    @Test
+    void generateRegistrationRequest() {
+        String softwareStatement = "software-statement";
+        AspspDetails aspspDetails = TestAspspDetails.builder()
+            .registrationIssuerUrl("registration-issuer-url")
+            .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+            .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
+            .registrationRequiresLowerCaseJtiClaim(false)
+            .build();
+
+        ClientRegistrationRequest clientRegistrationRequest = registrationRequestService.generateRegistrationRequest(
+            softwareStatement,
+            aspspDetails);
+
+        Assertions.assertTrue(clientRegistrationRequest.getIat() > 0);
+        Assertions.assertTrue(clientRegistrationRequest.getExp() > 0);
+        Assertions.assertTrue(clientRegistrationRequest.getExp() > clientRegistrationRequest.getIat());
+        Assertions.assertNull(clientRegistrationRequest.getTlsClientAuthSubjectDn());
+        Assertions.assertNull(clientRegistrationRequest.getTokenEndpointAuthSigningAlg());
+        Assertions.assertTrue(clientRegistrationRequest.getJti().matches(JTI_UPPERCASE_REGEX));
+        Assertions.assertEquals("openid payments", clientRegistrationRequest.getScope());
+        Assertions.assertEquals(ApplicationType.WEB, clientRegistrationRequest.getApplicationType());
+        Assertions.assertEquals(softwareStatement, clientRegistrationRequest.getSoftwareStatement());
+        Assertions.assertEquals(aspspDetails.getRegistrationIssuerUrl(), clientRegistrationRequest.getAud());
+        Assertions.assertEquals(aspspDetails.getGrantTypes(), clientRegistrationRequest.getGrantTypes());
+        Assertions.assertEquals(aspspDetails.getClientAuthenticationMethod().getMethodName(),
+            clientRegistrationRequest.getTokenEndpointAuthMethod());
+        Assertions.assertEquals(aspspDetails.getSigningAlgorithm(),
+            clientRegistrationRequest.getIdTokenSignedResponseAlg());
+        Assertions.assertEquals(aspspDetails.getSigningAlgorithm(),
+            clientRegistrationRequest.getRequestObjectSigningAlg());
+        Assertions.assertEquals(tppConfiguration.getSoftwareStatementId(), clientRegistrationRequest.getIss());
+        Assertions.assertEquals(tppConfiguration.getSoftwareStatementId(), clientRegistrationRequest.getSoftwareId());
+        Assertions.assertEquals(List.of(tppConfiguration.getRedirectUrl()),
+            clientRegistrationRequest.getRedirectUris());
+    }
+
+    @Test
+    void generateRegistrationRequestUsesLowerCaseJtiIfAspspRequiresIt() {
+        String softwareStatement = "software-statement";
+        AspspDetails aspspDetails = TestAspspDetails.builder()
+            .registrationIssuerUrl("registration-issuer-url")
+            .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.PRIVATE_KEY_JWT)
+            .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
+            .registrationRequiresLowerCaseJtiClaim(true)
+            .build();
+
+        ClientRegistrationRequest clientRegistrationRequest = registrationRequestService.generateRegistrationRequest(
+            softwareStatement,
+            aspspDetails);
+
+        Assertions.assertTrue(clientRegistrationRequest.getJti().matches(JTI_LOWERCASE_REGEX));
+    }
+
+    @Test
+    void generateRegistrationRequestAlwaysIncludesOpenIdPermissionInScopes() {
+        String softwareStatement = "software-statement";
+        AspspDetails aspspDetails = TestAspspDetails.builder()
+            .registrationIssuerUrl("registration-issuer-url")
+            .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.PRIVATE_KEY_JWT)
+            .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
+            .registrationRequiresLowerCaseJtiClaim(false)
+            .build();
+        tppConfiguration.setPermissions(List.of(RegistrationPermission.PAYMENTS));
+
+        ClientRegistrationRequest clientRegistrationRequest = registrationRequestService.generateRegistrationRequest(
+            softwareStatement,
+            aspspDetails);
+
+        Assertions.assertEquals("openid payments", clientRegistrationRequest.getScope());
+    }
+
+    @Test
+    void generateRegistrationRequestSetsClaimsWhenAspspUsesTlsClientAuth() throws Exception {
+        String softwareStatement = "software-statement";
+        AspspDetails aspspDetails = TestAspspDetails.builder()
+            .registrationIssuerUrl("registration-issuer-url")
+            .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.TLS_CLIENT_AUTH)
+            .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
+            .registrationRequiresLowerCaseJtiClaim(false)
+            .build();
+
+        X509Certificate transportCertificate = TestKeyUtils.aCertificate();
+        Mockito.when(keySupplier.getTransportCertificate(Mockito.eq(aspspDetails)))
+            .thenReturn(transportCertificate);
+
+        ClientRegistrationRequest clientRegistrationRequest = registrationRequestService.generateRegistrationRequest(
+            softwareStatement,
+            aspspDetails);
+
+        Assertions.assertEquals(transportCertificate.getSubjectX500Principal().getName(),
+            clientRegistrationRequest.getTlsClientAuthSubjectDn());
+    }
+
+    @Test
+    void generateRegistrationRequestSetsClaimsWhenAspspUsesPrivateKeyJwtClientAuth() {
+        String softwareStatement = "software-statement";
+        AspspDetails aspspDetails = TestAspspDetails.builder()
+            .registrationIssuerUrl("registration-issuer-url")
+            .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
+            .clientAuthenticationMethod(ClientAuthenticationMethod.PRIVATE_KEY_JWT)
+            .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
+            .registrationRequiresLowerCaseJtiClaim(false)
+            .build();
+
+        ClientRegistrationRequest clientRegistrationRequest = registrationRequestService.generateRegistrationRequest(
+            softwareStatement,
+            aspspDetails);
+
+        Assertions.assertEquals(aspspDetails.getSigningAlgorithm(),
+            clientRegistrationRequest.getTokenEndpointAuthSigningAlg());
+    }
+
+    private TppConfiguration aTppConfiguration() {
+        return TppConfiguration.builder()
+            .softwareStatementId("software-statement-id")
+            .permissions(List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS))
+            .redirectUrl("tpp-redirect-url")
+            .build();
+    }
+}

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -1,14 +1,23 @@
 package com.transferwise.openbanking.client.api.registration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
+import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
+import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.test.TestAspspDetails;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -20,56 +29,87 @@ import org.springframework.web.client.RestTemplate;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+@ExtendWith(MockitoExtension.class)
 @SuppressWarnings("PMD.UnusedPrivateMethod") // PMD considers argumentsForRegisterClientTest unused
-public class RestRegistrationClientTest {
+class RestRegistrationClientTest {
+
+    private static ObjectMapper objectMapper;
+
+    @Mock
+    private JwtClaimsSigner jwtClaimsSigner;
 
     private MockRestServiceServer mockAspspServer;
 
     private RestRegistrationClient restRegistrationClient;
+
+    @BeforeAll
+    static void initAll() {
+        objectMapper = new ObjectMapper();
+    }
 
     @BeforeEach
     void init() {
         RestTemplate restTemplate = new RestTemplate();
         mockAspspServer = MockRestServiceServer.createServer(restTemplate);
 
-        restRegistrationClient = new RestRegistrationClient(restTemplate);
+        restRegistrationClient = new RestRegistrationClient(jwtClaimsSigner, restTemplate);
     }
 
     @ParameterizedTest
     @MethodSource("argumentsForRegisterClientTest")
-    void registerClient(boolean registrationUsesJoseContentType, String expectedContentType) {
-        String softwareStatementAssertion = "software-statement-assertion";
+    void registerClient(boolean registrationUsesJoseContentType, String expectedContentType) throws Exception {
+        ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
         AspspDetails aspspDetails = aAspspDefinition(registrationUsesJoseContentType);
 
-        String mockJsonResponse = "json-response";
+        String signedClaims = "signed-claims";
+        Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
+            .thenReturn(signedClaims);
+
+        ClientRegistrationResponse mockResponse = ClientRegistrationResponse.builder()
+            .clientId("client-id")
+            .build();
+        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl()))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, expectedContentType))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name().toLowerCase()))
-            .andRespond(MockRestResponseCreators.withSuccess(mockJsonResponse, MediaType.APPLICATION_JSON));
+            .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT_CHARSET,
+                StandardCharsets.UTF_8.name().toLowerCase()))
+            .andExpect(MockRestRequestMatchers.content().string(signedClaims))
+            .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        String registrationResponse = restRegistrationClient.registerClient(softwareStatementAssertion,
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.registerClient(
+            clientRegistrationRequest,
             aspspDetails);
 
-        Assertions.assertEquals(mockJsonResponse, registrationResponse);
+        Assertions.assertEquals(mockResponse, registrationResponse);
 
         mockAspspServer.verify();
     }
 
     @Test
     void registerClientThrowsApiCallExceptionOnApiCallFailure() {
-        String softwareStatementAssertion = "software-statement-assertion";
+        ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
         AspspDetails aspspDetails = aAspspDefinition();
+
+        String signedClaims = "signed-claims";
+        Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
+            .thenReturn(signedClaims);
 
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl()))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withServerError());
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> restRegistrationClient.registerClient(softwareStatementAssertion, aspspDetails));
+            () -> restRegistrationClient.registerClient(clientRegistrationRequest, aspspDetails));
 
         mockAspspServer.verify();
+    }
+
+    private static ClientRegistrationRequest aRegistrationClaims() {
+        return ClientRegistrationRequest.builder()
+            .jti("jwt-id")
+            .build();
     }
 
     private static AspspDetails aAspspDefinition() {

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -1,8 +1,13 @@
 package com.transferwise.openbanking.client.test;
 
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
+import com.transferwise.openbanking.client.oauth.domain.GrantType;
+import com.transferwise.openbanking.client.oauth.domain.ResponseType;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 @Builder
@@ -12,15 +17,20 @@ public class TestAspspDetails implements AspspDetails {
     private String apiBaseUrl;
     private String tokenUrl;
     private String registrationUrl;
+    private String registrationIssuerUrl;
     private String tokenIssuerUrl;
     private String tppRedirectUrl;
+    private ClientAuthenticationMethod clientAuthenticationMethod;
     private String clientId;
     private String clientSecret;
     private String signingAlgorithm;
     private String signingKeyId;
+    private List<GrantType> grantTypes;
+    private List<ResponseType> responseTypes;
     private String paymentApiMinorVersion;
     private boolean registrationUsesJoseContentType;
     private boolean detachedSignatureUsesDirectoryIssFormat;
+    private boolean registrationRequiresLowerCaseJtiClaim;
 
     @Override
     public String getApiBaseUrl(String majorVersion, String resource) {
@@ -35,5 +45,10 @@ public class TestAspspDetails implements AspspDetails {
     @Override
     public boolean detachedSignatureUsesDirectoryIssFormat() {
         return detachedSignatureUsesDirectoryIssFormat;
+    }
+
+    @Override
+    public boolean registrationRequiresLowerCaseJtiClaim() {
+        return registrationRequiresLowerCaseJtiClaim;
     }
 }

--- a/src/test/java/com/transferwise/openbanking/client/test/TestKeyUtils.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestKeyUtils.java
@@ -1,0 +1,45 @@
+package com.transferwise.openbanking.client.test;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+public class TestKeyUtils {
+
+    public static KeyPair aKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    public static X509Certificate aCertificate() throws Exception {
+        return aCertificate(aKeyPair());
+    }
+
+    public static X509Certificate aCertificate(KeyPair keyPair) throws Exception {
+        X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+            new X500Name("CN=ISSUER_COMMON_NAME,O=ISSUER_ORGANISATION,C=GB"),
+            BigInteger.ONE,
+            Date.from(LocalDateTime.now().minusWeeks(1).toInstant(ZoneOffset.UTC)),
+            Date.from(LocalDateTime.now().plusWeeks(1).toInstant(ZoneOffset.UTC)),
+            new X500Name("CN=ORGANISATION_ID,O=ORGANISATION_NAME,C=GB"),
+            keyPair.getPublic());
+        ContentSigner contentSigner = new JcaContentSignerBuilder("SHA256WithRSA")
+            .build(keyPair.getPrivate());
+        return new JcaX509CertificateConverter()
+            .setProvider(new BouncyCastleProvider())
+            .getCertificate(certificateBuilder.build(contentSigner));
+    }
+}


### PR DESCRIPTION
## Context

The current dynamic client registration functionality is pretty limited, there is no functionality for building the registration request (a big part of the client registration logic) and the client class takes a raw string as the request body to send to the ASPSP, as well as returning the response body as a raw string.

This PR improves the situation by providing more functionality that TPPs need to implement dynamic client registration. The functionality is essentially copied from pisp-service but with a few tweaks to make it more configurable for different TPP use cases. 

## Changes

Expand the dynamic client registration functionality, providing new functionality for building the registration request to send to the ASPSP, and changing the client to return the registration response as a full data structure rather than a simple string.

Also update the code owners file to reflect the handover of the repository to a new team.
