### PR TITLE
Updating Client Registrations (PAYINP-779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2021-01-20
+### Added 
+- The `RegistrationClient` interface has a new method to update an existing client registration with an ASPSP
+- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a 
+  registration request with multiple TPP redirect URLs, and the `PaymentClient` now supports multiple TPP redirect URLs
+  when exchanging an authorization code as part of creating a domestic payment or checking funds availability
+### Changed
+- The `ID_TOKEN` value in the `ResponseType` enum is replaced with `CODE_AND_ID_TOKEN`, so that the enum defines only
+  the possible values required for the v3.2 client registration API, where it gets used for
+- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of 
+  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client 
+  registration API
+- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`  
+
 ## [1.0.1] - 2020-12-28
 ### Changed
 - Updated various dependencies to the latest versions, notably updating to Spring 5.3. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1
+version=2.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/common/AuthorizationContext.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/common/AuthorizationContext.java
@@ -1,0 +1,22 @@
+package com.transferwise.openbanking.client.api.payment.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorizationContext {
+    /**
+     * The authorization code returned by the ASPSP, as a result of a successful authorisation, which will be exchanged
+     * for an access token.
+     */
+    private String authorizationCode;
+    /**
+     * The TPP URL that was specified in the authorization request to the ASPSP.
+     */
+    private String redirectUrl;
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/common/BasePaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/common/BasePaymentClient.java
@@ -1,7 +1,6 @@
 package com.transferwise.openbanking.client.api.payment.common;
 
 import com.transferwise.openbanking.client.configuration.AspspDetails;
-import com.transferwise.openbanking.client.configuration.TppConfiguration;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
 import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
 import com.transferwise.openbanking.client.oauth.domain.GetAccessTokenRequest;
@@ -17,7 +16,6 @@ public class BasePaymentClient {
 
     private static final String PAYMENTS_SCOPE = "payments";
 
-    protected final TppConfiguration tppConfiguration;
     protected final RestOperations restOperations;
 
     private final OAuthClient oAuthClient;
@@ -27,9 +25,10 @@ public class BasePaymentClient {
         return getAccessToken(getAccessTokenRequest, aspspDetails);
     }
 
-    protected String exchangeAuthorizationCode(String authorizationCode, AspspDetails aspspDetails) {
-        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.authorizationCodeRequest(authorizationCode,
-            tppConfiguration.getRedirectUrl());
+    protected String exchangeAuthorizationCode(AuthorizationContext authorizationContext, AspspDetails aspspDetails) {
+        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.authorizationCodeRequest(
+            authorizationContext.getAuthorizationCode(),
+            authorizationContext.getRedirectUrl());
         return getAccessToken(getAccessTokenRequest, aspspDetails);
     }
 

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
@@ -1,5 +1,6 @@
 package com.transferwise.openbanking.client.api.payment.v3;
 
+import com.transferwise.openbanking.client.api.payment.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentConsentRequest;
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentConsentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentRequest;
@@ -35,8 +36,7 @@ public interface PaymentClient {
      * or otherwise stores access tokens, then the issue is avoided.
      *
      * @param domesticPaymentRequest The details of the payment to submit for execution
-     * @param authorizationCode      The payment authorization code returned by the ASPSP, as a result of a successful
-     *                               payment authorization by the account holder
+     * @param authorizationContext   The successful payment authorisation data
      * @param aspspDetails           The details of the ASPSP to send the request to
      * @return The result, from the ASPSP, of the domestic payment submission request
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
@@ -44,7 +44,7 @@ public interface PaymentClient {
      *                                                                   failed
      */
     DomesticPaymentResponse submitDomesticPayment(DomesticPaymentRequest domesticPaymentRequest,
-                                                  String authorizationCode,
+                                                  AuthorizationContext authorizationContext,
                                                   AspspDetails aspspDetails);
 
     /**
@@ -80,16 +80,15 @@ public interface PaymentClient {
      * {@link com.transferwise.openbanking.client.error.ApiCallException} will be thrown. If the implementation caches
      * or otherwise stores access tokens, then the issue is avoided.
      *
-     * @param consentId         The ID of the domestic payment consent to get the funds confirmation for
-     * @param authorizationCode The payment authorization code returned by the ASPSP, as a result of a successful
-     *                          payment authorization by the account holder
-     * @param aspspDetails      The details of the ASPSP to send the request to
+     * @param consentId            The ID of the domestic payment consent to get the funds confirmation for
+     * @param authorizationContext The successful payment authorisation data
+     * @param aspspDetails         The details of the ASPSP to send the request to
      * @return The confirmation of funds for the domestic payment consent
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
      *                                                                   failed
      */
     FundsConfirmationResponse getFundsConfirmation(String consentId,
-                                                   String authorizationCode,
+                                                   AuthorizationContext authorizationContext,
                                                    AspspDetails aspspDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
@@ -1,6 +1,7 @@
 package com.transferwise.openbanking.client.api.payment.v3;
 
 import com.transferwise.openbanking.client.api.common.OpenBankingHeaders;
+import com.transferwise.openbanking.client.api.payment.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.payment.common.BasePaymentClient;
 import com.transferwise.openbanking.client.api.payment.common.IdempotencyKeyGenerator;
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentConsentRequest;
@@ -9,7 +10,6 @@ import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPayment
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.domain.FundsConfirmationResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
-import com.transferwise.openbanking.client.configuration.TppConfiguration;
 import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -32,12 +32,11 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
     private final IdempotencyKeyGenerator<DomesticPaymentConsentRequest, DomesticPaymentRequest> idempotencyKeyGenerator;
     private final JwtClaimsSigner jwtClaimsSigner;
 
-    public RestPaymentClient(TppConfiguration tppConfiguration,
-                             RestOperations restOperations,
+    public RestPaymentClient(RestOperations restOperations,
                              OAuthClient oAuthClient,
                              IdempotencyKeyGenerator<DomesticPaymentConsentRequest, DomesticPaymentRequest> idempotencyKeyGenerator,
                              JwtClaimsSigner jwtClaimsSigner) {
-        super(tppConfiguration, restOperations, oAuthClient);
+        super(restOperations, oAuthClient);
         this.idempotencyKeyGenerator = idempotencyKeyGenerator;
         this.jwtClaimsSigner = jwtClaimsSigner;
     }
@@ -78,11 +77,11 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
     @Override
     public DomesticPaymentResponse submitDomesticPayment(DomesticPaymentRequest domesticPaymentRequest,
-                                                         String authorizationCode,
+                                                         AuthorizationContext authorizationContext,
                                                          AspspDetails aspspDetails) {
 
         OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getFinancialId(),
-            exchangeAuthorizationCode(authorizationCode, aspspDetails),
+            exchangeAuthorizationCode(authorizationContext, aspspDetails),
             idempotencyKeyGenerator.generateKeyForSubmission(domesticPaymentRequest),
             jwtClaimsSigner.createDetachedSignature(domesticPaymentRequest, aspspDetails));
 
@@ -174,11 +173,11 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
     @Override
     public FundsConfirmationResponse getFundsConfirmation(String consentId,
-                                                          String authorizationCode,
+                                                          AuthorizationContext authorizationContext,
                                                           AspspDetails aspspDetails) {
 
         OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getFinancialId(),
-            exchangeAuthorizationCode(authorizationCode, aspspDetails));
+            exchangeAuthorizationCode(authorizationContext, aspspDetails));
 
         HttpEntity<?> request = new HttpEntity<>(headers);
 

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
@@ -13,7 +13,7 @@ public interface RegistrationClient {
      * Register as a TPP client with an ASPSP.
      *
      * @param clientRegistrationRequest The details (JWT claims) of the registration request
-     * @param aspspDetails The details of the ASPSP to send the request to
+     * @param aspspDetails              The details of the ASPSP to send the request to
      * @return The response body from the ASPSP, containing the details of the registration
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
@@ -21,4 +21,18 @@ public interface RegistrationClient {
      */
     ClientRegistrationResponse registerClient(ClientRegistrationRequest clientRegistrationRequest,
                                               AspspDetails aspspDetails);
+
+    /**
+     * Update an existing TPP client registration with an ASPSP.
+     *
+     * @param clientRegistrationRequest The details (JWT claims) of the new registration request, this MUST contain
+     *                                  both the claims to change, and those which are unchanged
+     * @param aspspDetails              THe details of the ASPSP to send the request to
+     * @return The response body from the ASPSP, containing the details of the updated registration
+     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
+     *                                                                   to the ASPSP or the HTTP call to the ASPSP
+     *                                                                   failed
+     */
+    ClientRegistrationResponse updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
+                                                  AspspDetails aspspDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -47,7 +47,7 @@ public class RegistrationRequestService {
             .tokenEndpointAuthMethod(clientAuthenticationMethod.getMethodName())
             .idTokenSignedResponseAlg(signingAlgorithm)
             .requestObjectSigningAlg(signingAlgorithm)
-            .redirectUris(List.of(tppConfiguration.getRedirectUrl()));
+            .redirectUris(tppConfiguration.getRedirectUrls());
 
         if (ClientAuthenticationMethod.TLS_CLIENT_AUTH == clientAuthenticationMethod) {
             requestBuilder.tlsClientAuthSubjectDn(getTransportCertificateSubjectName(aspspDetails));

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -47,7 +47,8 @@ public class RegistrationRequestService {
             .tokenEndpointAuthMethod(clientAuthenticationMethod.getMethodName())
             .idTokenSignedResponseAlg(signingAlgorithm)
             .requestObjectSigningAlg(signingAlgorithm)
-            .redirectUris(tppConfiguration.getRedirectUrls());
+            .redirectUris(tppConfiguration.getRedirectUrls())
+            .clientId(aspspDetails.getClientId());
 
         if (ClientAuthenticationMethod.TLS_CLIENT_AUTH == clientAuthenticationMethod) {
             requestBuilder.tlsClientAuthSubjectDn(getTransportCertificateSubjectName(aspspDetails));

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -149,10 +149,10 @@ public interface AspspDetails {
      * Get the OAUth response types, that the ASPSP supports and the TPP may request, to specify to the ASPSP during
      * registration.
      *
-     * @return the response types to specify, defaults to all types
+     * @return the response types to specify, defaults to <code>CODE_AND_ID_TOKEN</code>
      */
     default List<ResponseType> getResponseTypes() {
-        return List.of(ResponseType.values());
+        return List.of(ResponseType.CODE_AND_ID_TOKEN);
     }
 
     /**

--- a/src/main/java/com/transferwise/openbanking/client/configuration/TppConfiguration.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/TppConfiguration.java
@@ -25,9 +25,9 @@ public class TppConfiguration {
     private String softwareStatementId;
 
     /**
-     * The URL that ASPSPs will redirect the user back to once the authorisation process is finished.
+     * The URLs that ASPSPs can redirect the user back to once the authorisation process is finished.
      */
-    private String redirectUrl;
+    private List<String> redirectUrls;
 
     /**
      * The permissions that the TPP has, according to the National Competent Authority (the FCA), and wants to use when

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
@@ -26,6 +26,11 @@ public class GetAccessTokenRequest {
     private final Map<String, String> requestBody = new HashMap<>();
     private final FapiHeaders requestHeaders = FapiHeaders.defaultHeaders();
 
+    public static GetAccessTokenRequest clientCredentialsRequest() {
+        return new GetAccessTokenRequest()
+            .setGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
+    }
+
     public static GetAccessTokenRequest clientCredentialsRequest(String scope) {
         return new GetAccessTokenRequest()
             .setGrantType(CLIENT_CREDENTIALS_GRANT_TYPE)

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/ResponseType.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/ResponseType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 public enum ResponseType {
 
     CODE("code"),
-    ID_TOKEN("id_token");
+    CODE_AND_ID_TOKEN("code id_token");
 
     private final String value;
 

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
@@ -79,8 +79,7 @@ class RegistrationRequestServiceTest {
             clientRegistrationRequest.getRequestObjectSigningAlg());
         Assertions.assertEquals(tppConfiguration.getSoftwareStatementId(), clientRegistrationRequest.getIss());
         Assertions.assertEquals(tppConfiguration.getSoftwareStatementId(), clientRegistrationRequest.getSoftwareId());
-        Assertions.assertEquals(List.of(tppConfiguration.getRedirectUrl()),
-            clientRegistrationRequest.getRedirectUris());
+        Assertions.assertEquals(tppConfiguration.getRedirectUrls(), clientRegistrationRequest.getRedirectUris());
     }
 
     @Test
@@ -166,7 +165,7 @@ class RegistrationRequestServiceTest {
         return TppConfiguration.builder()
             .softwareStatementId("software-statement-id")
             .permissions(List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS))
-            .redirectUrl("tpp-redirect-url")
+            .redirectUrls(List.of("https://tpp.co.uk/1", "https://tpp.co.uk/2"))
             .build();
     }
 }


### PR DESCRIPTION
## Context

We need to update our client registrations with ASPSPs to add a new TPP redirect URL. There is an optional API in the Open Banking standard to do this, that some ASPSPs support.

https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html

## Changes

To allow the above registration update, this PR adds support for calling the update client registration API, and support for generating a registration request with multiple TPP redirect URLs in it. Each individual commit contains further details on the change. 
