### PR TITLE
Update Registration Operation (PAYINP-777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2012-01-27
+### Changed
+- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as 
+  certain ASPSPs require a scope value to be set. 
+
 ## [2.0.0] - 2021-01-20
 ### Added 
 - The `RegistrationClient` interface has a new method to update an existing client registration with an ASPSP

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.0
+version=2.0.1

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -117,8 +117,8 @@ public class RestRegistrationClient implements RegistrationClient {
     }
 
     private String getClientCredentialsToken(AspspDetails aspspDetails) {
-        // for the registration operations, a scope doesn't need to be specified in the client credentials grant
-        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest();
+        // the spec states a scope value isn't strictly needed, but some ASPSPs do actually require it
+        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest("openid");
         AccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
         return accessTokenResponse.getAccessToken();
     }

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
@@ -26,11 +26,6 @@ public class GetAccessTokenRequest {
     private final Map<String, String> requestBody = new HashMap<>();
     private final FapiHeaders requestHeaders = FapiHeaders.defaultHeaders();
 
-    public static GetAccessTokenRequest clientCredentialsRequest() {
-        return new GetAccessTokenRequest()
-            .setGrantType(CLIENT_CREDENTIALS_GRANT_TYPE);
-    }
-
     public static GetAccessTokenRequest clientCredentialsRequest(String scope) {
         return new GetAccessTokenRequest()
             .setGrantType(CLIENT_CREDENTIALS_GRANT_TYPE)

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -126,7 +126,7 @@ class RestRegistrationClientTest {
             .when(oAuthClient.getAccessToken(
                 Mockito.argThat(request ->
                     "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
-                        !request.getRequestBody().containsKey("scope")),
+                        "openid".equals(request.getRequestBody().get("scope"))),
                 Mockito.eq(aspspDetails)))
             .thenReturn(mockAccessTokenResponse);
 


### PR DESCRIPTION
## Context

Certain ASPSPs reject requests to get an access token, when no scope parameter is specified in the request. This causes attempts to update a client registration to fail. 

## Changes

When getting an access token prior to calling the update client registration endpoint, specify a scope of `openid` in the access token request.

While the registration specification states it's not strictly required, some ASPSPs require the scope parameter to be present in the access token request. As this access token won't be used for the accounts or payments API, we can use the `openid` scope to avoid having to worry about what permission the TPP already has and using that.
