### PR TITLE
Payinp 777 update registration scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1] - 2012-01-27
+## [2.0.2] - 2021-02-01
+### Changed
+- When requesting an access token for the update client registration API call, set the scope parameter to `payments`, 
+  as certain ASPSPs require a scope value, not including `openid`, to be set .
+
+## [2.0.1] - 2021-01-27
 ### Changed
 - When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as 
   certain ASPSPs require a scope value to be set. 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.1
+version=2.0.2

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -26,6 +26,19 @@ public class RegistrationRequestService {
     private final KeySupplier keySupplier;
     private final TppConfiguration tppConfiguration;
 
+    /**
+     * Generate the claims for a client registration request to a given ASPSP, which can then be signed and used as the
+     * request body for calls to the ASPSP's client registration API.
+     * <p>
+     * The claims are generated based on the details defined in the supplied {@link AspspDetails} and the
+     * current values in the {@link TppConfiguration}.
+     * <p>
+     * The generated claims can then be further modified prior to being signed and sent to the ASPSP.
+     *
+     * @param softwareStatement The software statement assertion, issued by the Open Banking directory
+     * @param aspspDetails The details of the ASPSP, for which the registration claims will be sent to
+     * @return The generated registration claims
+     */
     public ClientRegistrationRequest generateRegistrationRequest(String softwareStatement, AspspDetails aspspDetails) {
         Instant now = Instant.now();
 

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -117,8 +117,13 @@ public class RestRegistrationClient implements RegistrationClient {
     }
 
     private String getClientCredentialsToken(AspspDetails aspspDetails) {
-        // the spec states a scope value isn't strictly needed, but some ASPSPs do actually require it
-        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest("openid");
+        // The spec states a scope value isn't strictly needed, but some ASPSPs do actually require it, additionally
+        // some do not accept the general `openid` scope and require either `accounts` or `payments` scope.
+        // We could take the value from the `TppConfiguration.permissions` property, but if the TPP is trying to update
+        // the scope of their registration, this will contain a permission that we can't use here. So rather than trying
+        // to figure out what the TPP has vs what they are requesting, we use `payments` as given this library only has
+        // payments support it's most likely the TPP currently has this permission on their registration.
+        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest("payments");
         AccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
         return accessTokenResponse.getAccessToken();
     }

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -126,7 +126,7 @@ class RestRegistrationClientTest {
             .when(oAuthClient.getAccessToken(
                 Mockito.argThat(request ->
                     "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
-                        "openid".equals(request.getRequestBody().get("scope"))),
+                        "payments".equals(request.getRequestBody().get("scope"))),
                 Mockito.eq(aspspDetails)))
             .thenReturn(mockAccessTokenResponse);
 


### PR DESCRIPTION
## Context

Certain ASPSPs reject requests to get an access token, when a scope of `openid` is specified in the request. This causes attempts to update a client registration to fail.

## Changes

When getting an access token prior to calling the update client registration endpoint, specify a scope of `payments` in the access token request.

Some ASPSPs do not support requesting a scope of only `openid`, using `payments` instead should be fine for now instead and allow the update client registration operation to succeed for these ASPSPs.
