### PR TITLE
Multiple Software Statement Support (PAYINP-817)

### DIFF
--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
@@ -7,6 +7,7 @@ import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPayment
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.domain.FundsConfirmationResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 
 /**
  * An interface specifying the operations for a client supporting version 3 single immediate domestic payments.
@@ -18,6 +19,7 @@ public interface PaymentClient {
      *
      * @param domesticPaymentConsentRequest The details of the payment to setup
      * @param aspspDetails                  The details of the ASPSP to send the request to
+     * @param softwareStatementDetails      The details of the software statement that the ASPSP registration uses
      * @return The result, from the ASPSP, of the domestic payment consent request
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
@@ -25,7 +27,8 @@ public interface PaymentClient {
      */
     DomesticPaymentConsentResponse createDomesticPaymentConsent(
         DomesticPaymentConsentRequest domesticPaymentConsentRequest,
-        AspspDetails aspspDetails);
+        AspspDetails aspspDetails,
+        SoftwareStatementDetails softwareStatementDetails);
 
     /**
      * Submits a created and approved immediate domestic payment for execution by the ASPSP.
@@ -35,9 +38,10 @@ public interface PaymentClient {
      * {@link com.transferwise.openbanking.client.error.ApiCallException} will be thrown. If the implementation caches
      * or otherwise stores access tokens, then the issue is avoided.
      *
-     * @param domesticPaymentRequest The details of the payment to submit for execution
-     * @param authorizationContext   The successful payment authorisation data
-     * @param aspspDetails           The details of the ASPSP to send the request to
+     * @param domesticPaymentRequest   The details of the payment to submit for execution
+     * @param authorizationContext     The successful payment authorisation data
+     * @param aspspDetails             The details of the ASPSP to send the request to
+     * @param softwareStatementDetails The details of the software statement that the ASPSP registration uses
      * @return The result, from the ASPSP, of the domestic payment submission request
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
@@ -45,7 +49,8 @@ public interface PaymentClient {
      */
     DomesticPaymentResponse submitDomesticPayment(DomesticPaymentRequest domesticPaymentRequest,
                                                   AuthorizationContext authorizationContext,
-                                                  AspspDetails aspspDetails);
+                                                  AspspDetails aspspDetails,
+                                                  SoftwareStatementDetails softwareStatementDetails);
 
     /**
      * Get the details of a previously created domestic payment consent.

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
@@ -10,6 +10,7 @@ import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPayment
 import com.transferwise.openbanking.client.api.payment.v3.domain.DomesticPaymentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.domain.FundsConfirmationResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -44,12 +45,15 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
     @Override
     public DomesticPaymentConsentResponse createDomesticPaymentConsent(
         DomesticPaymentConsentRequest domesticPaymentConsentRequest,
-        AspspDetails aspspDetails) {
+        AspspDetails aspspDetails,
+        SoftwareStatementDetails softwareStatementDetails) {
 
         OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getFinancialId(),
             getClientCredentialsToken(aspspDetails),
             idempotencyKeyGenerator.generateKeyForSetup(domesticPaymentConsentRequest),
-            jwtClaimsSigner.createDetachedSignature(domesticPaymentConsentRequest, aspspDetails));
+            jwtClaimsSigner.createDetachedSignature(domesticPaymentConsentRequest,
+                aspspDetails,
+                softwareStatementDetails));
 
         HttpEntity<DomesticPaymentConsentRequest> request = new HttpEntity<>(domesticPaymentConsentRequest, headers);
 
@@ -78,12 +82,13 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
     @Override
     public DomesticPaymentResponse submitDomesticPayment(DomesticPaymentRequest domesticPaymentRequest,
                                                          AuthorizationContext authorizationContext,
-                                                         AspspDetails aspspDetails) {
+                                                         AspspDetails aspspDetails,
+                                                         SoftwareStatementDetails softwareStatementDetails) {
 
         OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getFinancialId(),
             exchangeAuthorizationCode(authorizationContext, aspspDetails),
             idempotencyKeyGenerator.generateKeyForSubmission(domesticPaymentRequest),
-            jwtClaimsSigner.createDetachedSignature(domesticPaymentRequest, aspspDetails));
+            jwtClaimsSigner.createDetachedSignature(domesticPaymentRequest, aspspDetails, softwareStatementDetails));
 
         HttpEntity<DomesticPaymentRequest> request = new HttpEntity<>(domesticPaymentRequest, headers);
 

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -1,10 +1,10 @@
 package com.transferwise.openbanking.client.api.registration;
 
 import com.transferwise.openbanking.client.api.registration.domain.ApplicationType;
-import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
-import com.transferwise.openbanking.client.configuration.TppConfiguration;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.error.ClientException;
 import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
 import com.transferwise.openbanking.client.security.KeySupplier;
@@ -24,43 +24,45 @@ public class RegistrationRequestService {
     private static final long REGISTRATION_TOKEN_VALIDITY_SECONDS = 300;
 
     private final KeySupplier keySupplier;
-    private final TppConfiguration tppConfiguration;
 
     /**
      * Generate the claims for a client registration request to a given ASPSP, which can then be signed and used as the
      * request body for calls to the ASPSP's client registration API.
      * <p>
-     * The claims are generated based on the details defined in the supplied {@link AspspDetails} and the
-     * current values in the {@link TppConfiguration}.
+     * The claims are generated based on the details defined in the supplied {@link SoftwareStatementDetails} and
+     * {@link AspspDetails}.
      * <p>
      * The generated claims can then be further modified prior to being signed and sent to the ASPSP.
      *
-     * @param softwareStatement The software statement assertion, issued by the Open Banking directory
-     * @param aspspDetails The details of the ASPSP, for which the registration claims will be sent to
+     * @param softwareStatementAssertion The software statement assertion, issued by the Open Banking directory
+     * @param softwareStatementDetails   The details of the software statement that the ASPSP will be registered against
+     * @param aspspDetails               The details of the ASPSP, for which the registration claims will be sent to
      * @return The generated registration claims
      */
-    public ClientRegistrationRequest generateRegistrationRequest(String softwareStatement, AspspDetails aspspDetails) {
+    public ClientRegistrationRequest generateRegistrationRequest(String softwareStatementAssertion,
+                                                                 SoftwareStatementDetails softwareStatementDetails,
+                                                                 AspspDetails aspspDetails) {
         Instant now = Instant.now();
 
         ClientAuthenticationMethod clientAuthenticationMethod = aspspDetails.getClientAuthenticationMethod();
         String signingAlgorithm = aspspDetails.getSigningAlgorithm();
 
         ClientRegistrationRequest.ClientRegistrationRequestBuilder requestBuilder = ClientRegistrationRequest.builder()
-            .iss(tppConfiguration.getSoftwareStatementId())
+            .iss(softwareStatementDetails.getSoftwareStatementId())
             .aud(aspspDetails.getRegistrationIssuerUrl())
             .iat(now.getEpochSecond())
             .exp(now.plusSeconds(REGISTRATION_TOKEN_VALIDITY_SECONDS).getEpochSecond())
             .jti(generateJwtIdValue(aspspDetails))
             .applicationType(ApplicationType.WEB)
-            .scope(generateScopeValue())
-            .softwareId(tppConfiguration.getSoftwareStatementId())
-            .softwareStatement(softwareStatement)
+            .scope(generateScopeValue(softwareStatementDetails))
+            .softwareId(softwareStatementDetails.getSoftwareStatementId())
+            .softwareStatement(softwareStatementAssertion)
             .grantTypes(aspspDetails.getGrantTypes())
             .responseTypes(aspspDetails.getResponseTypes())
             .tokenEndpointAuthMethod(clientAuthenticationMethod.getMethodName())
             .idTokenSignedResponseAlg(signingAlgorithm)
             .requestObjectSigningAlg(signingAlgorithm)
-            .redirectUris(tppConfiguration.getRedirectUrls())
+            .redirectUris(softwareStatementDetails.getRedirectUrls())
             .clientId(aspspDetails.getClientId());
 
         if (ClientAuthenticationMethod.TLS_CLIENT_AUTH == clientAuthenticationMethod) {
@@ -83,15 +85,15 @@ public class RegistrationRequestService {
         }
     }
 
-    private String generateScopeValue() {
+    private String generateScopeValue(SoftwareStatementDetails softwareStatementDetails) {
         List<RegistrationPermission> permissions;
         // registration requests always have to include the OPENID permission
-        if (tppConfiguration.getPermissions().contains(RegistrationPermission.OPENID)) {
-            permissions = tppConfiguration.getPermissions();
+        if (softwareStatementDetails.getPermissions().contains(RegistrationPermission.OPENID)) {
+            permissions = softwareStatementDetails.getPermissions();
         } else {
             permissions = new ArrayList<>();
             permissions.add(RegistrationPermission.OPENID);
-            permissions.addAll(tppConfiguration.getPermissions());
+            permissions.addAll(softwareStatementDetails.getPermissions());
         }
 
         return permissions.stream()

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -119,10 +119,10 @@ public class RestRegistrationClient implements RegistrationClient {
     private String getClientCredentialsToken(AspspDetails aspspDetails) {
         // The spec states a scope value isn't strictly needed, but some ASPSPs do actually require it, additionally
         // some do not accept the general `openid` scope and require either `accounts` or `payments` scope.
-        // We could take the value from the `TppConfiguration.permissions` property, but if the TPP is trying to update
-        // the scope of their registration, this will contain a permission that we can't use here. So rather than trying
-        // to figure out what the TPP has vs what they are requesting, we use `payments` as given this library only has
-        // payments support it's most likely the TPP currently has this permission on their registration.
+        // We could take the value from the `SoftwareStatementDetails.permissions` property, but if the TPP is trying to
+        // update the scope of their registration, this will contain a permission that we can't use here. So rather than
+        // trying to figure out what the TPP has vs what they are requesting, we use `payments` as given this library
+        // only has payments support it's most likely the TPP currently has this permission on their registration.
         GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest("payments");
         AccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
         return accessTokenResponse.getAccessToken();

--- a/src/main/java/com/transferwise/openbanking/client/configuration/SoftwareStatementDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/SoftwareStatementDetails.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TppConfiguration {
+public class SoftwareStatementDetails {
 
     /**
      * The TPP organisation ID, within the Open Banking directory.

--- a/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
@@ -25,6 +25,7 @@ import com.transferwise.openbanking.client.api.payment.v3.domain.Initiation;
 import com.transferwise.openbanking.client.api.payment.v3.domain.PaymentConsentStatus;
 import com.transferwise.openbanking.client.api.payment.v3.domain.PaymentStatus;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -97,6 +98,7 @@ class RestPaymentClientTest {
     void createDomesticPaymentConsent() throws Exception {
         DomesticPaymentConsentRequest domesticPaymentConsentRequest = aDomesticPaymentConsentRequest();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito
@@ -110,7 +112,11 @@ class RestPaymentClientTest {
         Mockito.when(idempotencyKeyGenerator.generateKeyForSetup(domesticPaymentConsentRequest))
             .thenReturn(IDEMPOTENCY_KEY);
 
-        Mockito.when(jwtClaimsSigner.createDetachedSignature(domesticPaymentConsentRequest, aspspDetails))
+        Mockito.when(
+            jwtClaimsSigner.createDetachedSignature(
+                domesticPaymentConsentRequest,
+                aspspDetails,
+                softwareStatementDetails))
             .thenReturn(DETACHED_JWS_SIGNATURE);
 
         DomesticPaymentConsentResponse mockPaymentConsentResponse = aDomesticPaymentConsentResponse();
@@ -129,7 +135,8 @@ class RestPaymentClientTest {
 
         DomesticPaymentConsentResponse paymentConsentResponse = restPaymentClient.createDomesticPaymentConsent(
             domesticPaymentConsentRequest,
-            aspspDetails);
+            aspspDetails,
+            softwareStatementDetails);
 
         Assertions.assertEquals(mockPaymentConsentResponse, paymentConsentResponse);
 
@@ -140,6 +147,7 @@ class RestPaymentClientTest {
     void createDomesticPaymentConsentThrowsApiCallExceptionOnApiCallFailure() {
         DomesticPaymentConsentRequest domesticPaymentConsentRequest = aDomesticPaymentConsentRequest();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
@@ -153,7 +161,10 @@ class RestPaymentClientTest {
             .andRespond(MockRestResponseCreators.withServerError());
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> restPaymentClient.createDomesticPaymentConsent(domesticPaymentConsentRequest, aspspDetails));
+            () -> restPaymentClient.createDomesticPaymentConsent(
+                domesticPaymentConsentRequest,
+                aspspDetails,
+                softwareStatementDetails));
 
         mockAspspServer.verify();
     }
@@ -165,6 +176,7 @@ class RestPaymentClientTest {
 
         DomesticPaymentConsentRequest domesticPaymentConsentRequest = aDomesticPaymentConsentRequest();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
@@ -179,7 +191,10 @@ class RestPaymentClientTest {
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> restPaymentClient.createDomesticPaymentConsent(domesticPaymentConsentRequest, aspspDetails));
+            () -> restPaymentClient.createDomesticPaymentConsent(
+                domesticPaymentConsentRequest,
+                aspspDetails,
+                softwareStatementDetails));
 
         mockAspspServer.verify();
     }
@@ -188,6 +203,7 @@ class RestPaymentClientTest {
     void submitDomesticPayment() throws Exception {
         DomesticPaymentRequest domesticPaymentRequest = aDomesticPaymentRequest();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AuthorizationContext authorizationContext = aAuthorizationContext();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
@@ -203,7 +219,11 @@ class RestPaymentClientTest {
         Mockito.when(idempotencyKeyGenerator.generateKeyForSubmission(domesticPaymentRequest))
             .thenReturn(IDEMPOTENCY_KEY);
 
-        Mockito.when(jwtClaimsSigner.createDetachedSignature(domesticPaymentRequest, aspspDetails))
+        Mockito.when(
+            jwtClaimsSigner.createDetachedSignature(
+                domesticPaymentRequest,
+                aspspDetails,
+                softwareStatementDetails))
             .thenReturn(DETACHED_JWS_SIGNATURE);
 
         DomesticPaymentResponse mockDomesticPaymentResponse = aDomesticPaymentResponse();
@@ -223,7 +243,8 @@ class RestPaymentClientTest {
         DomesticPaymentResponse domesticPaymentResponse = restPaymentClient.submitDomesticPayment(
             domesticPaymentRequest,
             authorizationContext,
-            aspspDetails);
+            aspspDetails,
+            softwareStatementDetails);
 
         Assertions.assertEquals(mockDomesticPaymentResponse, domesticPaymentResponse);
 
@@ -234,6 +255,7 @@ class RestPaymentClientTest {
     void submitDomesticPaymentThrowsApiCallExceptionOnApiCallFailure() {
         DomesticPaymentRequest domesticPaymentRequest = aDomesticPaymentRequest();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AuthorizationContext authorizationContext = aAuthorizationContext();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
@@ -248,7 +270,11 @@ class RestPaymentClientTest {
             .andRespond(MockRestResponseCreators.withBadRequest());
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> restPaymentClient.submitDomesticPayment(domesticPaymentRequest, authorizationContext, aspspDetails));
+            () -> restPaymentClient.submitDomesticPayment(
+                domesticPaymentRequest,
+                authorizationContext,
+                aspspDetails,
+                softwareStatementDetails));
 
         mockAspspServer.verify();
     }
@@ -260,6 +286,7 @@ class RestPaymentClientTest {
 
         DomesticPaymentRequest domesticPaymentRequest = aDomesticPaymentRequest();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AuthorizationContext authorizationContext = aAuthorizationContext();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
@@ -275,7 +302,11 @@ class RestPaymentClientTest {
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> restPaymentClient.submitDomesticPayment(domesticPaymentRequest, authorizationContext, aspspDetails));
+            () -> restPaymentClient.submitDomesticPayment(
+                domesticPaymentRequest,
+                authorizationContext,
+                aspspDetails,
+                softwareStatementDetails));
 
         mockAspspServer.verify();
     }
@@ -310,7 +341,8 @@ class RestPaymentClientTest {
 
         Assertions.assertEquals(mockDomesticPaymentConsentResponse, domesticPaymentConsentResponse);
 
-        Mockito.verify(jwtClaimsSigner, Mockito.never()).createDetachedSignature(Mockito.any(), Mockito.any());
+        Mockito.verify(jwtClaimsSigner, Mockito.never())
+            .createDetachedSignature(Mockito.any(), Mockito.any(), Mockito.any());
 
         mockAspspServer.verify();
     }
@@ -385,7 +417,8 @@ class RestPaymentClientTest {
 
         Assertions.assertEquals(mockDomesticPaymentResponse, domesticPaymentResponse);
 
-        Mockito.verify(jwtClaimsSigner, Mockito.never()).createDetachedSignature(Mockito.any(), Mockito.any());
+        Mockito.verify(jwtClaimsSigner, Mockito.never())
+            .createDetachedSignature(Mockito.any(), Mockito.any(), Mockito.any());
 
         mockAspspServer.verify();
     }
@@ -462,7 +495,8 @@ class RestPaymentClientTest {
 
         Assertions.assertEquals(mockFundsConfirmationResponse, fundsConfirmationResponse);
 
-        Mockito.verify(jwtClaimsSigner, Mockito.never()).createDetachedSignature(Mockito.any(), Mockito.any());
+        Mockito.verify(jwtClaimsSigner, Mockito.never())
+            .createDetachedSignature(Mockito.any(), Mockito.any(), Mockito.any());
 
         mockAspspServer.verify();
     }
@@ -514,6 +548,11 @@ class RestPaymentClientTest {
             .apiBaseUrl("https://aspsp.co.uk")
             .tppRedirectUrl("tpp-redirect-url")
             .paymentApiMinorVersion("1")
+            .build();
+    }
+
+    private SoftwareStatementDetails aSoftwareStatementDetails() {
+        return SoftwareStatementDetails.builder()
             .build();
     }
 


### PR DESCRIPTION
## Context

Make it easier for the client library to work with multiple software statements at the same time, without having to go through extra hoops of creating separate instances of classes per software statement. 

## Changes

Refactor the classes which use the `TppConfiguration` class as a class variable, to instead take an instance of the class as a method parameter.

This makes it easier to have multiple `TppConfiguration` in use at the same time, without having to create separate instances of the classes which use it.

Also rename the `TppConfiguration` class to `SoftwareStatementDetails` to better describe what the class now represents, i.e. the details of the software statement to use for the ASPSP integration.
