### PR TITLE
Registration fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2021-02-15
+### Changed
+- Refactor the classes which use the `TppConfiguration` class as a class variable, to instead take an instance of the
+  class as a method parameter. This makes it easier to have multiple `TppConfiguration` in use at the same time,
+  without having to create separate instances of the classes which use it.
+- Rename the `TppConfiguration` class to `SoftwareStatementDetails`, to better describe what it now represents.
+- Rename the `RegistrationRequestService` `generateRegistrationRequest` `softwareStatement` method parameter to better
+  differentiate it and the `softwareStatementDetails` parameter.
+- Change the `clientIdIssuedAt` and `clientSecretExpiresAt` fields in the `ClientRegistrationResponse` class from type
+  `Integer` to type `String`, to handle ASPSPs that return timestamps in these fields instead of integers.
+- When requesting an access token for the update client registration API call, decide whether or not to include `openid`
+  in the scope parameter, based on the ASPSP integration details via the new 
+  `registrationAuthenticationRequiresOpenIdScope` method.
+
 ## [2.0.2] - 2021-02-01
 ### Changed
 - When requesting an access token for the update client registration API call, set the scope parameter to `payments`, 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.0.2
+version=3.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
@@ -3,6 +3,7 @@ package com.transferwise.openbanking.client.api.registration;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 
 /**
  * An interface specifying the operations for a client supporting TPP registrations with an ASPSP.
@@ -27,12 +28,14 @@ public interface RegistrationClient {
      *
      * @param clientRegistrationRequest The details (JWT claims) of the new registration request, this MUST contain
      *                                  both the claims to change, and those which are unchanged
-     * @param aspspDetails              THe details of the ASPSP to send the request to
+     * @param aspspDetails              The details of the ASPSP to send the request to
+     * @param softwareStatementDetails  The details of the software statement that the ASPSP registration currently uses
      * @return The response body from the ASPSP, containing the details of the updated registration
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
      *                                                                   failed
      */
     ClientRegistrationResponse updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
-                                                  AspspDetails aspspDetails);
+                                                  AspspDetails aspspDetails,
+                                                  SoftwareStatementDetails softwareStatementDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -2,7 +2,9 @@ package com.transferwise.openbanking.client.api.registration;
 
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -20,7 +22,10 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestOperations;
 
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -74,7 +79,8 @@ public class RestRegistrationClient implements RegistrationClient {
 
     @Override
     public ClientRegistrationResponse updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
-                                                         AspspDetails aspspDetails) {
+                                                         AspspDetails aspspDetails,
+                                                         SoftwareStatementDetails softwareStatementDetails) {
 
         HttpHeaders headers = new HttpHeaders();
         if (aspspDetails.registrationUsesJoseContentType()) {
@@ -85,7 +91,7 @@ public class RestRegistrationClient implements RegistrationClient {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         // as we're using a raw String as the body type, we need to manually set the header
         headers.setAcceptCharset(List.of(StandardCharsets.UTF_8));
-        headers.setBearerAuth(getClientCredentialsToken(aspspDetails));
+        headers.setBearerAuth(getClientCredentialsToken(aspspDetails, softwareStatementDetails));
 
         String signedClaims = jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails);
         HttpEntity<String> request = new HttpEntity<>(signedClaims, headers);
@@ -116,15 +122,29 @@ public class RestRegistrationClient implements RegistrationClient {
         }
     }
 
-    private String getClientCredentialsToken(AspspDetails aspspDetails) {
-        // The spec states a scope value isn't strictly needed, but some ASPSPs do actually require it, additionally
-        // some do not accept the general `openid` scope and require either `accounts` or `payments` scope.
-        // We could take the value from the `SoftwareStatementDetails.permissions` property, but if the TPP is trying to
-        // update the scope of their registration, this will contain a permission that we can't use here. So rather than
-        // trying to figure out what the TPP has vs what they are requesting, we use `payments` as given this library
-        // only has payments support it's most likely the TPP currently has this permission on their registration.
-        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest("payments");
+    private String getClientCredentialsToken(AspspDetails aspspDetails,
+                                             SoftwareStatementDetails softwareStatementDetails) {
+        String scope = generateScopeValue(aspspDetails, softwareStatementDetails);
+        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest(scope);
         AccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
         return accessTokenResponse.getAccessToken();
+    }
+
+    private String generateScopeValue(AspspDetails aspspDetails, SoftwareStatementDetails softwareStatementDetails) {
+        // The spec states a scope value isn't strictly needed, but some ASPSPs do actually require it, additionally
+        // some require the scope to contain `openid` but some require it to not contain `openid`. As we request a
+        // scope of what the permissions the software statement details currently has, we don't really support updating
+        // the permissions of a client registration, but as this can't be modified in the Open Banking directory this
+        // shouldn't be an issue.
+        Set<RegistrationPermission> permissions = new LinkedHashSet<>(softwareStatementDetails.getPermissions());
+        if (aspspDetails.registrationAuthenticationRequiresOpenIdScope()) {
+            permissions.add(RegistrationPermission.OPENID);
+        } else {
+            permissions.remove(RegistrationPermission.OPENID);
+        }
+
+        return permissions.stream()
+            .map(RegistrationPermission::getValue)
+            .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ClientRegistrationResponse.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ClientRegistrationResponse.java
@@ -29,9 +29,13 @@ public class ClientRegistrationResponse {
 
     private String clientSecret;
 
-    private Integer clientIdIssuedAt;
+    // this should be an integer, containing seconds since epoch, but some ASPSPs incorrectly return a formatted
+    // timestamp, so we use a string to keep things simple and avoid de-serialisation issues
+    private String clientIdIssuedAt;
 
-    private Integer clientSecretExpiresAt;
+    // this should be an integer, containing seconds since epoch, but some ASPSPs incorrectly return a formatted
+    // timestamp, so we use a string to keep things simple and avoid de-serialisation issues
+    private String clientSecretExpiresAt;
 
     private List<String> redirectUris;
 

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -207,4 +207,14 @@ public interface AspspDetails {
     default boolean registrationRequiresLowerCaseJtiClaim() {
         return false;
     }
+
+    /**
+     * Whether or not the ASPSP requires the access token, used as the authorisation for get / update / delete client
+     * registration API calls, to have the openid scope.
+     *
+     * @return {@code true} if the authorisation must have the openid scope, {@code false} if it must not.
+     */
+    default boolean registrationAuthenticationRequiresOpenIdScope() {
+        return true;
+    }
 }

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -3,7 +3,9 @@ package com.transferwise.openbanking.client.api.registration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -29,6 +31,7 @@ import org.springframework.test.web.client.response.MockRestResponseCreators;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,7 +64,7 @@ class RestRegistrationClientTest {
     }
 
     @ParameterizedTest
-    @MethodSource("argumentsForRegisterClientTest")
+    @MethodSource("argumentsForContentTypeTest")
     void registerClient(boolean registrationUsesJoseContentType, String expectedContentType) throws Exception {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
         AspspDetails aspspDetails = aAspspDefinition(registrationUsesJoseContentType);
@@ -96,7 +99,7 @@ class RestRegistrationClientTest {
     @Test
     void registerClientHandlesTimestampIssuedAtValues() {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
-        AspspDetails aspspDetails = aAspspDefinition(false);
+        AspspDetails aspspDetails = aAspspDefinition();
 
         String signedClaims = "signed-claims";
         Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
@@ -140,13 +143,11 @@ class RestRegistrationClientTest {
         mockAspspServer.verify();
     }
 
-    @ParameterizedTest
-    @MethodSource("argumentsForRegisterClientTest")
-    void updateRegistration(boolean registrationUsesJoseContentType, String expectedContentType)
-        throws Exception {
-
+    @Test
+    void updateRegistration() throws Exception {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
-        AspspDetails aspspDetails = aAspspDefinition(registrationUsesJoseContentType);
+        AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
         AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
             .accessToken("access-token")
@@ -169,7 +170,7 @@ class RestRegistrationClientTest {
         String jsonResponse = objectMapper.writeValueAsString(mockResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
-            .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, expectedContentType))
+            .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, "application/jwt"))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT_CHARSET,
                 StandardCharsets.UTF_8.name().toLowerCase()))
@@ -179,7 +180,91 @@ class RestRegistrationClientTest {
 
         ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
             clientRegistrationRequest,
-            aspspDetails);
+            aspspDetails,
+            softwareStatementDetails);
+
+        Assertions.assertEquals(mockResponse, registrationResponse);
+
+        mockAspspServer.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForContentTypeTest")
+    void updateRegistrationSupportsDifferentContentTypes(boolean registrationUsesJoseContentType,
+                                                         String expectedContentType)
+        throws Exception {
+
+        ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
+        AspspDetails aspspDetails = aAspspDefinition(registrationUsesJoseContentType);
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
+
+        AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
+            .accessToken("access-token")
+            .build();
+        Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
+            .thenReturn(mockAccessTokenResponse);
+
+        String signedClaims = "signed-claims";
+        Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
+            .thenReturn(signedClaims);
+
+        ClientRegistrationResponse mockResponse = ClientRegistrationResponse.builder()
+            .clientId("client-id")
+            .build();
+        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
+        mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
+            .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, expectedContentType))
+            .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
+            clientRegistrationRequest,
+            aspspDetails,
+            softwareStatementDetails);
+
+        Assertions.assertEquals(mockResponse, registrationResponse);
+
+        mockAspspServer.verify();
+    }
+
+    @ParameterizedTest
+    @MethodSource("argumentsForAuthenticationScopeTest")
+    void updateRegistrationSupportsDifferentAuthenticationScopes(boolean registrationAuthenticationRequiresOpenIdScope,
+                                                                 List<RegistrationPermission> tppPermissions,
+                                                                 String expectedAuthenticationScope)
+        throws Exception {
+
+        ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
+        AspspDetails aspspDetails = aAspspDefinition(false, registrationAuthenticationRequiresOpenIdScope);
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails(tppPermissions);
+
+        AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
+            .accessToken("access-token")
+            .build();
+        Mockito
+            .when(oAuthClient.getAccessToken(
+                Mockito.argThat(request ->
+                    "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
+                        expectedAuthenticationScope.equals(request.getRequestBody().get("scope"))),
+                Mockito.eq(aspspDetails)))
+            .thenReturn(mockAccessTokenResponse);
+
+        String signedClaims = "signed-claims";
+        Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
+            .thenReturn(signedClaims);
+
+        ClientRegistrationResponse mockResponse = ClientRegistrationResponse.builder()
+            .clientId("client-id")
+            .build();
+        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
+        mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
+            .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
+
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
+            clientRegistrationRequest,
+            aspspDetails,
+            softwareStatementDetails);
 
         Assertions.assertEquals(mockResponse, registrationResponse);
 
@@ -190,6 +275,7 @@ class RestRegistrationClientTest {
     void updateRegistrationThrowsApiCallExceptionOnApiCallFailure() {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
         AspspDetails aspspDetails = aAspspDefinition();
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
         AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
             .accessToken("access-token")
@@ -206,7 +292,10 @@ class RestRegistrationClientTest {
             .andRespond(MockRestResponseCreators.withServerError());
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> restRegistrationClient.updateRegistration(clientRegistrationRequest, aspspDetails));
+            () -> restRegistrationClient.updateRegistration(
+                clientRegistrationRequest,
+                aspspDetails,
+                softwareStatementDetails));
 
         mockAspspServer.verify();
     }
@@ -232,10 +321,43 @@ class RestRegistrationClientTest {
             .build();
     }
 
-    private static Stream<Arguments> argumentsForRegisterClientTest() {
+    private static AspspDetails aAspspDefinition(boolean registrationUsesJoseContentType,
+                                                 boolean registrationAuthenticationRequiresOpenIdScope) {
+        return TestAspspDetails.builder()
+            .registrationUrl("/registration-url")
+            .registrationUsesJoseContentType(registrationUsesJoseContentType)
+            .registrationAuthenticationRequiresOpenIdScope(registrationAuthenticationRequiresOpenIdScope)
+            .clientId("client-id")
+            .build();
+    }
+
+    private static SoftwareStatementDetails aSoftwareStatementDetails() {
+        return SoftwareStatementDetails.builder()
+            .permissions(List.of(RegistrationPermission.PAYMENTS))
+            .build();
+    }
+
+    private static SoftwareStatementDetails aSoftwareStatementDetails(List<RegistrationPermission> permissions) {
+        return SoftwareStatementDetails.builder()
+            .permissions(permissions)
+            .build();
+    }
+
+    private static Stream<Arguments> argumentsForContentTypeTest() {
         return Stream.of(
             Arguments.of(false, "application/jwt"),
             Arguments.of(true, "application/jose")
+        );
+    }
+
+    private static Stream<Arguments> argumentsForAuthenticationScopeTest() {
+        return Stream.of(
+            Arguments.of(false, List.of(RegistrationPermission.PAYMENTS), "payments"),
+            Arguments.of(false, List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS), "payments"),
+            Arguments.of(true, List.of(RegistrationPermission.PAYMENTS), "payments openid"),
+            Arguments.of(true,
+                List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS),
+                "openid payments")
         );
     }
 }

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -31,6 +31,7 @@ public class TestAspspDetails implements AspspDetails {
     private boolean registrationUsesJoseContentType;
     private boolean detachedSignatureUsesDirectoryIssFormat;
     private boolean registrationRequiresLowerCaseJtiClaim;
+    private boolean registrationAuthenticationRequiresOpenIdScope;
 
     @Override
     public String getApiBaseUrl(String majorVersion, String resource) {
@@ -50,5 +51,10 @@ public class TestAspspDetails implements AspspDetails {
     @Override
     public boolean registrationRequiresLowerCaseJtiClaim() {
         return registrationRequiresLowerCaseJtiClaim;
+    }
+
+    @Override
+    public boolean registrationAuthenticationRequiresOpenIdScope() {
+        return registrationAuthenticationRequiresOpenIdScope;
     }
 }


### PR DESCRIPTION
## Context

As we've started making use of the update client registration API endpoint, we've discovered two quirks in ASPSP implementations, this PR allows this library to gracefully handle them. 

## Changes

See individual commits for details. 
