### PR TITLE
Aspsp Details Interface Refactoring

### DIFF
--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
@@ -48,7 +48,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails) {
 
-        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getFinancialId(),
+        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getOrganisationId(),
             getClientCredentialsToken(aspspDetails),
             idempotencyKeyGenerator.generateKeyForSetup(domesticPaymentConsentRequest),
             jwtClaimsSigner.createDetachedSignature(domesticPaymentConsentRequest,
@@ -85,7 +85,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                                                          AspspDetails aspspDetails,
                                                          SoftwareStatementDetails softwareStatementDetails) {
 
-        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getFinancialId(),
+        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getOrganisationId(),
             exchangeAuthorizationCode(authorizationContext, aspspDetails),
             idempotencyKeyGenerator.generateKeyForSubmission(domesticPaymentRequest),
             jwtClaimsSigner.createDetachedSignature(domesticPaymentRequest, aspspDetails, softwareStatementDetails));
@@ -117,7 +117,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
     @Override
     public DomesticPaymentConsentResponse getDomesticPaymentConsent(String consentId, AspspDetails aspspDetails) {
 
-        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getFinancialId(),
+        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getOrganisationId(),
             getClientCredentialsToken(aspspDetails));
 
         HttpEntity<?> request = new HttpEntity<>(headers);
@@ -148,7 +148,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
     @Override
     public DomesticPaymentResponse getDomesticPayment(String domesticPaymentId, AspspDetails aspspDetails) {
 
-        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getFinancialId(),
+        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getOrganisationId(),
             getClientCredentialsToken(aspspDetails));
 
         HttpEntity<?> request = new HttpEntity<>(headers);
@@ -181,7 +181,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                                                           AuthorizationContext authorizationContext,
                                                           AspspDetails aspspDetails) {
 
-        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getFinancialId(),
+        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getOrganisationId(),
             exchangeAuthorizationCode(authorizationContext, aspspDetails));
 
         HttpEntity<?> request = new HttpEntity<>(headers);

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -49,7 +49,7 @@ public class RegistrationRequestService {
 
         ClientRegistrationRequest.ClientRegistrationRequestBuilder requestBuilder = ClientRegistrationRequest.builder()
             .iss(softwareStatementDetails.getSoftwareStatementId())
-            .aud(aspspDetails.getRegistrationIssuerUrl())
+            .aud(aspspDetails.getRegistrationAudience())
             .iat(now.getEpochSecond())
             .exp(now.plusSeconds(REGISTRATION_TOKEN_VALIDITY_SECONDS).getEpochSecond())
             .jti(generateJwtIdValue(aspspDetails))

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -48,7 +48,7 @@ public class RegistrationRequestService {
         String signingAlgorithm = aspspDetails.getSigningAlgorithm();
 
         ClientRegistrationRequest.ClientRegistrationRequestBuilder requestBuilder = ClientRegistrationRequest.builder()
-            .iss(softwareStatementDetails.getSoftwareStatementId())
+            .iss(aspspDetails.getRegistrationIssuer(softwareStatementDetails))
             .aud(aspspDetails.getRegistrationAudience())
             .iat(now.getEpochSecond())
             .exp(now.plusSeconds(REGISTRATION_TOKEN_VALIDITY_SECONDS).getEpochSecond())

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -76,6 +76,17 @@ public interface AspspDetails {
     }
 
     /**
+     * Get the value to use as the issuer claim within a client registration request. For most ASPSPs this will be the
+     * ID of the software statement used for the registration, however some ASPSPs may require a different value.
+     *
+     * @param softwareStatementDetails the details of the software statement being used for the registration
+     * @return the issuer claim value to use, defaults to the software statement ID
+     */
+    default String getRegistrationIssuer(SoftwareStatementDetails softwareStatementDetails) {
+        return softwareStatementDetails.getSoftwareStatementId();
+    }
+
+    /**
      * Get the URL to use as the intended audience value for a JWT generated for requesting an OAuth access token.
      *
      * <p>This URL is only applicable for certain client authentication methods, namely

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -23,17 +23,17 @@ public interface AspspDetails {
     String getInternalId();
 
     /**
-     * Get the identifier, assigned by a central service, of the ASPSP.
+     * Get the identifier, assigned by the Open Banking directory, for the ASPSP organisation.
      *
-     * <p>This value cannot be considered as a unique ASPSP identifier as the same value may be used across several banks
-     * within the same group.
+     * <p>This value cannot be considered as a unique ASPSP identifier as the same value may be used across several
+     * ASPSP brands within the same organisation.
      *
      * <p>This value also cannot be considered as a human friendly identifier, as values are randomly assigned and have
      * no correlation to the ASPSP name.
      *
-     * @return the financial identifier for the ASPSP
+     * @return the organisation identifier for the ASPSP
      */
-    String getFinancialId();
+    String getOrganisationId();
 
     /**
      * Get the base URL for the ASPSPs Open Banking API, to use as the prefix for an API call to the ASPSP.

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -87,19 +87,6 @@ public interface AspspDetails {
     }
 
     /**
-     * Get the URL to use as the intended audience value for a JWT generated for requesting an OAuth access token.
-     *
-     * <p>This URL is only applicable for certain client authentication methods, namely
-     * {@link com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod#PRIVATE_KEY_JWT}, therefore not all
-     * implementations implement this method.
-     *
-     * @return the JWT intended audience URL
-     */
-    default String getTokenIssuerUrl() {
-        throw new UnsupportedOperationException("getTokenIssuerUrl not implemented");
-    }
-
-    /**
      * Get the authentication method to use for identifying ourselves as a client to the ASPSP.
      *
      * @return the client authentication method to use
@@ -127,6 +114,16 @@ public interface AspspDetails {
      */
     default String getClientSecret() {
         throw new UnsupportedOperationException("getClientSecret not implemented");
+    }
+
+    /**
+     * Get the value to use as the intended audience claim, in the JWT generated for requesting an OAuth access token,
+     * when using the private key JWT client authentication method.
+     *
+     * @return the JWT intended audience claim value to use, defaults to the token URL
+     */
+    default String getPrivateKeyJwtAuthenticationAudience() {
+        return getTokenUrl();
     }
 
     /**

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -63,14 +63,16 @@ public interface AspspDetails {
     }
 
     /**
-     * Get the URL to use as the intended audience value for a JWT generated for a client registration.
+     * Get the value to use as the intended audience claim within a client registration request. For most ASPSPs this
+     * will be ASPSP organisation ID (within the Open Banking directory), however some ASPSPs may require a different
+     * value.
      *
      * <p>Not all ASPSPs support a registration API, therefore not all implementations implement this method.
      *
-     * @return the JWT intended audience URL
+     * @return the intended audience claim value to use
      */
-    default String getRegistrationIssuerUrl() {
-        throw new UnsupportedOperationException("getRegistrationIssuerUrl not implemented");
+    default String getRegistrationAudience() {
+        return getOrganisationId();
     }
 
     /**

--- a/src/main/java/com/transferwise/openbanking/client/oauth/PrivateKeyJwtAuthentication.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/PrivateKeyJwtAuthentication.java
@@ -37,7 +37,7 @@ public class PrivateKeyJwtAuthentication implements ClientAuthentication {
         JwtClaims jwtClaims = new JwtClaims();
         jwtClaims.setIssuer(aspspDetails.getClientId());
         jwtClaims.setSubject(aspspDetails.getClientId());
-        jwtClaims.setAudience(aspspDetails.getTokenIssuerUrl());
+        jwtClaims.setAudience(aspspDetails.getPrivateKeyJwtAuthenticationAudience());
         jwtClaims.setIssuedAtToNow();
         jwtClaims.setExpirationTimeMinutesInTheFuture(CLAIMS_VALID_FOR_MINUTES);
         jwtClaims.setJwtId(UUID.randomUUID().toString());

--- a/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
@@ -125,7 +125,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
-            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getFinancialId()))
+            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header("x-idempotency-key", IDEMPOTENCY_KEY))
             .andExpect(MockRestRequestMatchers.header("x-jws-signature", DETACHED_JWS_SIGNATURE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
@@ -232,7 +232,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
-            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getFinancialId()))
+            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header("x-idempotency-key", IDEMPOTENCY_KEY))
             .andExpect(MockRestRequestMatchers.header("x-jws-signature", DETACHED_JWS_SIGNATURE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
@@ -331,7 +331,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
-            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getFinancialId()))
+            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
@@ -408,7 +408,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
-            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getFinancialId()))
+            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
@@ -485,7 +485,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
-            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getFinancialId()))
+            .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
@@ -546,7 +546,6 @@ class RestPaymentClientTest {
     private AspspDetails aAspspDefinition() {
         return TestAspspDetails.builder()
             .apiBaseUrl("https://aspsp.co.uk")
-            .tppRedirectUrl("tpp-redirect-url")
             .paymentApiMinorVersion("1")
             .build();
     }

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
@@ -47,6 +47,7 @@ class RegistrationRequestServiceTest {
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AspspDetails aspspDetails = TestAspspDetails.builder()
             .registrationAudience("registration-issuer-url")
+            .registrationIssuer("organisation-id")
             .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
             .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
@@ -75,7 +76,7 @@ class RegistrationRequestServiceTest {
             clientRegistrationRequest.getIdTokenSignedResponseAlg());
         Assertions.assertEquals(aspspDetails.getSigningAlgorithm(),
             clientRegistrationRequest.getRequestObjectSigningAlg());
-        Assertions.assertEquals(softwareStatementDetails.getSoftwareStatementId(), clientRegistrationRequest.getIss());
+        Assertions.assertEquals("organisation-id", clientRegistrationRequest.getIss());
         Assertions.assertEquals(softwareStatementDetails.getSoftwareStatementId(),
             clientRegistrationRequest.getSoftwareId());
         Assertions.assertEquals(softwareStatementDetails.getRedirectUrls(),

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestServiceTest.java
@@ -46,7 +46,7 @@ class RegistrationRequestServiceTest {
         String softwareStatement = "software-statement";
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AspspDetails aspspDetails = TestAspspDetails.builder()
-            .registrationIssuerUrl("registration-issuer-url")
+            .registrationAudience("registration-issuer-url")
             .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
             .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
@@ -67,7 +67,7 @@ class RegistrationRequestServiceTest {
         Assertions.assertEquals("openid payments", clientRegistrationRequest.getScope());
         Assertions.assertEquals(ApplicationType.WEB, clientRegistrationRequest.getApplicationType());
         Assertions.assertEquals(softwareStatement, clientRegistrationRequest.getSoftwareStatement());
-        Assertions.assertEquals(aspspDetails.getRegistrationIssuerUrl(), clientRegistrationRequest.getAud());
+        Assertions.assertEquals(aspspDetails.getRegistrationAudience(), clientRegistrationRequest.getAud());
         Assertions.assertEquals(aspspDetails.getGrantTypes(), clientRegistrationRequest.getGrantTypes());
         Assertions.assertEquals(aspspDetails.getClientAuthenticationMethod().getMethodName(),
             clientRegistrationRequest.getTokenEndpointAuthMethod());
@@ -87,7 +87,7 @@ class RegistrationRequestServiceTest {
         String softwareStatement = "software-statement";
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AspspDetails aspspDetails = TestAspspDetails.builder()
-            .registrationIssuerUrl("registration-issuer-url")
+            .registrationAudience("registration-issuer-url")
             .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
             .clientAuthenticationMethod(ClientAuthenticationMethod.PRIVATE_KEY_JWT)
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
@@ -108,7 +108,7 @@ class RegistrationRequestServiceTest {
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         softwareStatementDetails.setPermissions(List.of(RegistrationPermission.PAYMENTS));
         AspspDetails aspspDetails = TestAspspDetails.builder()
-            .registrationIssuerUrl("registration-issuer-url")
+            .registrationAudience("registration-issuer-url")
             .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
             .clientAuthenticationMethod(ClientAuthenticationMethod.PRIVATE_KEY_JWT)
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
@@ -128,7 +128,7 @@ class RegistrationRequestServiceTest {
         String softwareStatement = "software-statement";
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AspspDetails aspspDetails = TestAspspDetails.builder()
-            .registrationIssuerUrl("registration-issuer-url")
+            .registrationAudience("registration-issuer-url")
             .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
             .clientAuthenticationMethod(ClientAuthenticationMethod.TLS_CLIENT_AUTH)
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
@@ -153,7 +153,7 @@ class RegistrationRequestServiceTest {
         String softwareStatement = "software-statement";
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
         AspspDetails aspspDetails = TestAspspDetails.builder()
-            .registrationIssuerUrl("registration-issuer-url")
+            .registrationAudience("registration-issuer-url")
             .grantTypes(List.of(GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE))
             .clientAuthenticationMethod(ClientAuthenticationMethod.PRIVATE_KEY_JWT)
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)

--- a/src/test/java/com/transferwise/openbanking/client/oauth/PrivateKeyJwtAuthenticationTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/oauth/PrivateKeyJwtAuthenticationTest.java
@@ -14,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class PrivateKeyJwtAuthenticationTest {
@@ -46,7 +46,7 @@ class PrivateKeyJwtAuthenticationTest {
                 try {
                     return jwtClaims.getIssuer().equals(aspspDetails.getClientId()) &&
                         jwtClaims.getSubject().equals(aspspDetails.getClientId()) &&
-                        jwtClaims.getAudience().equals(Collections.singletonList(aspspDetails.getTokenIssuerUrl())) &&
+                        jwtClaims.getAudience().equals(List.of(aspspDetails.getPrivateKeyJwtAuthenticationAudience())) &&
                         jwtClaims.getIssuedAt() != null &&
                         jwtClaims.getExpirationTime().isAfter(jwtClaims.getIssuedAt()) &&
                         jwtClaims.getJwtId() != null;
@@ -67,7 +67,7 @@ class PrivateKeyJwtAuthenticationTest {
     private AspspDetails aAspspDefinition() {
         return TestAspspDetails.builder()
             .clientId("client-id")
-            .tokenIssuerUrl("/token-issuer-url")
+            .privateKeyJwtAuthenticationAudience("/token-issuer-url")
             .signingAlgorithm(AlgorithmIdentifiers.RSA_PSS_USING_SHA256)
             .build();
     }

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -20,11 +20,11 @@ public class TestAspspDetails implements AspspDetails {
     private String registrationUrl;
     private String registrationAudience;
     private String registrationIssuer;
-    private String tokenIssuerUrl;
     private String tppRedirectUrl;
     private ClientAuthenticationMethod clientAuthenticationMethod;
     private String clientId;
     private String clientSecret;
+    private String privateKeyJwtAuthenticationAudience;
     private String signingAlgorithm;
     private String signingKeyId;
     private List<GrantType> grantTypes;

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Builder
 public class TestAspspDetails implements AspspDetails {
     private String internalId;
-    private String financialId;
+    private String organisationId;
     private String apiBaseUrl;
     private String tokenUrl;
     private String registrationUrl;

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -20,7 +20,6 @@ public class TestAspspDetails implements AspspDetails {
     private String registrationUrl;
     private String registrationAudience;
     private String registrationIssuer;
-    private String tppRedirectUrl;
     private ClientAuthenticationMethod clientAuthenticationMethod;
     private String clientId;
     private String clientSecret;

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -1,6 +1,7 @@
 package com.transferwise.openbanking.client.test;
 
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
 import com.transferwise.openbanking.client.oauth.domain.GrantType;
 import com.transferwise.openbanking.client.oauth.domain.ResponseType;
@@ -18,6 +19,7 @@ public class TestAspspDetails implements AspspDetails {
     private String tokenUrl;
     private String registrationUrl;
     private String registrationAudience;
+    private String registrationIssuer;
     private String tokenIssuerUrl;
     private String tppRedirectUrl;
     private ClientAuthenticationMethod clientAuthenticationMethod;
@@ -36,6 +38,11 @@ public class TestAspspDetails implements AspspDetails {
     @Override
     public String getApiBaseUrl(String majorVersion, String resource) {
         return apiBaseUrl;
+    }
+
+    @Override
+    public String getRegistrationIssuer(SoftwareStatementDetails softwareStatementDetails) {
+        return registrationIssuer;
     }
 
     @Override

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -17,7 +17,7 @@ public class TestAspspDetails implements AspspDetails {
     private String apiBaseUrl;
     private String tokenUrl;
     private String registrationUrl;
-    private String registrationIssuerUrl;
+    private String registrationAudience;
     private String tokenIssuerUrl;
     private String tppRedirectUrl;
     private ClientAuthenticationMethod clientAuthenticationMethod;


### PR DESCRIPTION
## Context

Certain ASPSPs require a non-standard `iss` value to be provided in the registration request, as opposed to the standard value of the 'software statement ID', therefore it would be nice if the value to use could be easily customised via the `AspspDetails` interface (where we customise other behaviour).  

While adding this functionality I also felt that several other methods in the `AspspDetails` interface had slightly unclear / confusing names, and could have better default values where there is a clear standard value to use. 

Note, I haven't bumped up the changelog or version in this PR as I plan to roll these changes into the release notes for https://github.com/transferwise/openbanking-client/pull/8

## Changes

See individual commits for details. 