### PR TITLE
JSON Serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2021-04-20
+### Added
+- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the 
+  `JacksonJsonConverter` implementing the interface
+### Changed
+- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the 
+  `ObjectMapper` optional argument
+- The V3 `RestPaymentClient` class now requires a `JsonConverter` to be passed as a constructor argument. This is used
+  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance, 
+  fixing an issue with null object fields being included in the serialised JSON request body
+- Updated the Spotless Gradle plugin version used in the build configuration
+
 ## [4.0.0] - 2021-01-22
 ### Changed
 - The payment model classes are now generated dynamically from the Open Banking specification swagger definitions,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The V3 `RestPaymentClient` class now requires a `JsonConverter` to be passed as a constructor argument. This is used
   to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance, 
   fixing an issue with null object fields being included in the serialised JSON request body
-- Updated the Spotless Gradle plugin version used in the build configuration
+- Update the versions of various dependencies and plugins in the Gradle build configuration
 
 ## [4.0.0] - 2021-01-22
 ### Changed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ RestTemplate restTemplate = new RestTemplate();
 
 // an example implementation might look up the values to supply from a KeyStore
 KeySupplier signingKeySupplier = new ExampleKeySupplier();
-JwtClaimsSigner jwtClaimsSigner = new JwtClaimsSigner(signingKeySupplier, tppConfiguration);
+JsonConverter jsonConverter = new JacksonJsonConverter();
+JwtClaimsSigner jwtClaimsSigner = new JwtClaimsSigner(signingKeySupplier, jsonConverter);
 
 RegistrationClient registrationClient = new RestRegistrationClient(jwtClaimsSigner, restTemplate);
 
@@ -75,11 +76,12 @@ IdempotencyKeyGenerator idempotencyKeyGenerator = new ExampleIdempotencyKeyGener
 
 // an example implementation might look up the values to supply from a KeyStore
 KeySupplier signingKeySupplier = new ExampleKeySupplier();
-JwtClaimsSigner jwtClaimsSigner = new JwtClaimsSigner(signingKeySupplier, tppConfiguration);
+JsonConverter jsonConverter = new JacksonJsonConverter();
+JwtClaimsSigner jwtClaimsSigner = new JwtClaimsSigner(signingKeySupplier, jsonConverter);
 
-PaymentClient paymentClient = new RestPaymentClient(tppConfiguration,
-    restTemplate,
-    tlsClientAuthentication,
+PaymentClient paymentClient = new RestPaymentClient(restTemplate,
+    jsonConverter,
+    restOAuthClient,
     idempotencyKeyGenerator,
     jwtClaimsSigner);
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,11 @@ targetCompatibility = JavaVersion.VERSION_11
 
 ext {
     libs = [
-        'spring': '5.3.2',
-        'jackson': '2.12.2',
-        'lombok': '1.18.18',
+        'spring': '5.3.6',
+        'jackson': '2.12.3',
+        'lombok': '1.18.20',
         'junit': '5.7.1',
-        'mockito': '3.8.0'
+        'mockito': '3.9.0'
     ]
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:${libs.jackson}")
     api("com.fasterxml.jackson.core:jackson-databind:${libs.jackson}")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${libs.jackson}")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${libs.jackson}")
 
     api('org.bitbucket.b_c:jose4j:0.7.6')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.0.0
+version=5.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/common/BasePaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/common/BasePaymentClient.java
@@ -1,6 +1,7 @@
 package com.transferwise.openbanking.client.api.payment.common;
 
 import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
 import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
 import com.transferwise.openbanking.client.oauth.domain.GetAccessTokenRequest;
@@ -17,6 +18,7 @@ public class BasePaymentClient {
     private static final String PAYMENTS_SCOPE = "payments";
 
     protected final RestOperations restOperations;
+    protected final JsonConverter jsonConverter;
 
     private final OAuthClient oAuthClient;
 

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
@@ -49,7 +49,7 @@ public interface PaymentClient {
     OBWriteDomesticResponse5 submitDomesticPayment(OBWriteDomestic2 domesticPaymentRequest,
                                                    AuthorizationContext authorizationContext,
                                                    AspspDetails aspspDetails,
-                                                  SoftwareStatementDetails softwareStatementDetails);
+                                                   SoftwareStatementDetails softwareStatementDetails);
 
     /**
      * Get the details of a previously created domestic payment consent.

--- a/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
@@ -1,0 +1,49 @@
+package com.transferwise.openbanking.client.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.transferwise.openbanking.client.error.ClientException;
+
+/**
+ * Implementation of the {@link JsonConverter} interface, using the Jackson library for JSON operations.
+ * <p>
+ * Instances of this class are thread safe and can be re-used to to avoid un-necessarily creating multiple instances of
+ * the heavy {@link ObjectMapper} class.
+ */
+public class JacksonJsonConverter implements JsonConverter {
+
+    private final ObjectMapper objectMapper;
+
+    public JacksonJsonConverter() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.configure(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    }
+
+    @Override
+    public String writeValueAsString(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new ClientException("Unable to serialize object to JSON string", e);
+        }
+    }
+
+    @Override
+    public <T> T readValue(String content, Class<T> valueType) {
+        try {
+            return objectMapper.readValue(content, valueType);
+        } catch (JsonProcessingException e) {
+            throw new ClientException("Unable to read JSON string to object", e);
+        }
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/json/JsonConverter.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JsonConverter.java
@@ -1,0 +1,25 @@
+package com.transferwise.openbanking.client.json;
+
+/**
+ * An interface specifying the operations for serializing and de-serializing JSON.
+ */
+public interface JsonConverter {
+
+    /**
+     * Serialize the given object as a JSON string.
+     *
+     * @param value The object to serialize
+     * @return The serialized JSON string
+     */
+    String writeValueAsString(Object value);
+
+    /**
+     * De-serialize the given JSON string to a Java object.
+     *
+     * @param content The JSON string to de-serialize
+     * @param valueType The class type to de-serialize to
+     * @param <T> The type to de-serialize to
+     * @return The de-serialized JSON object
+     */
+    <T> T readValue(String content, Class<T> valueType);
+}

--- a/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
@@ -1,6 +1,5 @@
 package com.transferwise.openbanking.client.api.payment.v3;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.openbanking.client.api.payment.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.payment.common.IdempotencyKeyGenerator;
 import com.transferwise.openbanking.client.api.payment.v3.model.OBExternalAccountIdentification4Code;
@@ -24,6 +23,8 @@ import com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConf
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.error.ApiCallException;
+import com.transferwise.openbanking.client.json.JacksonJsonConverter;
+import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
 import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
@@ -60,7 +61,7 @@ class RestPaymentClientTest {
 
     private static final String DETACHED_JWS_SIGNATURE = "detached-jws-signature";
 
-    private static ObjectMapper objectMapper;
+    private static JsonConverter jsonConverter;
 
     @Mock
     private OAuthClient oAuthClient;
@@ -77,7 +78,7 @@ class RestPaymentClientTest {
 
     @BeforeAll
     static void initAll() {
-        objectMapper = new ObjectMapper();
+        jsonConverter = new JacksonJsonConverter();
     }
 
     @BeforeEach
@@ -86,6 +87,7 @@ class RestPaymentClientTest {
         mockAspspServer = MockRestServiceServer.createServer(restTemplate);
 
         restPaymentClient = new RestPaymentClient(restTemplate,
+            jsonConverter,
             oAuthClient,
             idempotencyKeyGenerator,
             jwtClaimsSigner);
@@ -117,7 +119,7 @@ class RestPaymentClientTest {
             .thenReturn(DETACHED_JWS_SIGNATURE);
 
         OBWriteDomesticConsentResponse5 mockPaymentConsentResponse = aDomesticPaymentConsentResponse();
-        String jsonResponse = objectMapper.writeValueAsString(mockPaymentConsentResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockPaymentConsentResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payment-consents"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
@@ -127,7 +129,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.header("x-jws-signature", DETACHED_JWS_SIGNATURE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(MockRestRequestMatchers.content().json(objectMapper.writeValueAsString(domesticPaymentConsentRequest)))
+            .andExpect(MockRestRequestMatchers.content().json(jsonConverter.writeValueAsString(domesticPaymentConsentRequest)))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         OBWriteDomesticConsentResponse5 paymentConsentResponse = restPaymentClient.createDomesticPaymentConsent(
@@ -182,7 +184,7 @@ class RestPaymentClientTest {
         Mockito.when(idempotencyKeyGenerator.generateKeyForSetup(Mockito.any(OBWriteDomesticConsent4.class)))
             .thenReturn(IDEMPOTENCY_KEY);
 
-        String jsonResponse = objectMapper.writeValueAsString(response);
+        String jsonResponse = jsonConverter.writeValueAsString(response);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payment-consents"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
@@ -224,7 +226,7 @@ class RestPaymentClientTest {
             .thenReturn(DETACHED_JWS_SIGNATURE);
 
         OBWriteDomesticResponse5 mockDomesticPaymentResponse = aDomesticPaymentResponse();
-        String jsonResponse = objectMapper.writeValueAsString(mockDomesticPaymentResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockDomesticPaymentResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payments"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
@@ -234,7 +236,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.header("x-jws-signature", DETACHED_JWS_SIGNATURE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(MockRestRequestMatchers.content().json(objectMapper.writeValueAsString(domesticPaymentRequest)))
+            .andExpect(MockRestRequestMatchers.content().json(jsonConverter.writeValueAsString(domesticPaymentRequest)))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         OBWriteDomesticResponse5 domesticPaymentResponse = restPaymentClient.submitDomesticPayment(domesticPaymentRequest,
@@ -292,7 +294,7 @@ class RestPaymentClientTest {
         Mockito.when(idempotencyKeyGenerator.generateKeyForSubmission(Mockito.any(OBWriteDomestic2.class)))
             .thenReturn(IDEMPOTENCY_KEY);
 
-        String jsonResponse = objectMapper.writeValueAsString(response);
+        String jsonResponse = jsonConverter.writeValueAsString(response);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payments"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
@@ -322,7 +324,7 @@ class RestPaymentClientTest {
             .thenReturn(accessTokenResponse);
 
         OBWriteDomesticConsentResponse5 mockDomesticPaymentConsentResponse = aDomesticPaymentConsentResponse();
-        String jsonResponse = objectMapper.writeValueAsString(mockDomesticPaymentConsentResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockDomesticPaymentConsentResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payment-consents/" + consentId))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
@@ -373,7 +375,7 @@ class RestPaymentClientTest {
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
             .thenReturn(accessTokenResponse);
 
-        String jsonResponse = objectMapper.writeValueAsString(response);
+        String jsonResponse = jsonConverter.writeValueAsString(response);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payment-consents/" + consentId))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
@@ -399,7 +401,7 @@ class RestPaymentClientTest {
             .thenReturn(accessTokenResponse);
 
         OBWriteDomesticResponse5 mockDomesticPaymentResponse = aDomesticPaymentResponse();
-        String jsonResponse = objectMapper.writeValueAsString(mockDomesticPaymentResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockDomesticPaymentResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payments/" + domesticPaymentId))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
@@ -448,7 +450,7 @@ class RestPaymentClientTest {
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
             .thenReturn(accessTokenResponse);
 
-        String jsonResponse = objectMapper.writeValueAsString(response);
+        String jsonResponse = jsonConverter.writeValueAsString(response);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payments/" + domesticPaymentId))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
@@ -476,7 +478,7 @@ class RestPaymentClientTest {
             .thenReturn(accessTokenResponse);
 
         OBWriteFundsConfirmationResponse1 mockFundsConfirmationResponse = aFundsConfirmationResponse();
-        String jsonResponse = objectMapper.writeValueAsString(mockFundsConfirmationResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockFundsConfirmationResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payment-consents/" + consentId + "/funds-confirmation"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
@@ -529,7 +531,7 @@ class RestPaymentClientTest {
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
             .thenReturn(accessTokenResponse);
 
-        String jsonResponse = objectMapper.writeValueAsString(response);
+        String jsonResponse = jsonConverter.writeValueAsString(response);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo("https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-payment-consents/" + consentId + "/funds-confirmation"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));

--- a/src/test/java/com/transferwise/openbanking/client/json/JacksonJsonConverterTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/json/JacksonJsonConverterTest.java
@@ -1,0 +1,39 @@
+package com.transferwise.openbanking.client.json;
+
+import com.transferwise.openbanking.client.api.payment.v3.model.OBExternalAccountIdentification4Code;
+import com.transferwise.openbanking.client.api.payment.v3.model.OBWriteDomestic2DataInitiationDebtorAccount;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class JacksonJsonConverterTest {
+
+    private static JacksonJsonConverter jsonConverter;
+
+    @BeforeAll
+    static void initAll() {
+        jsonConverter = new JacksonJsonConverter();
+    }
+
+    @Test
+    void writeValueAsStringProducesCorrectJson() {
+        OBWriteDomestic2DataInitiationDebtorAccount object = new OBWriteDomestic2DataInitiationDebtorAccount()
+            .schemeName(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER)
+            .name("Wise");
+
+        String json = jsonConverter.writeValueAsString(object);
+
+        Assertions.assertEquals("{\"SchemeName\":\"UK.OBIE.SortCodeAccountNumber\",\"Name\":\"Wise\"}", json);
+    }
+
+    @Test
+    void readValueProducesCorrectObject() {
+        String json = "{\"Name\": \"Wise\",\"Currency\": \"GBP\"}";
+
+        OBWriteDomestic2DataInitiationDebtorAccount object = jsonConverter.readValue(json,
+            OBWriteDomestic2DataInitiationDebtorAccount.class);
+
+        Assertions.assertEquals("Wise", object.getName());
+        Assertions.assertNull(object.getSchemeName());
+    }
+}

--- a/src/test/java/com/transferwise/openbanking/client/jwt/JwtClaimsSignerTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/jwt/JwtClaimsSignerTest.java
@@ -1,9 +1,10 @@
 package com.transferwise.openbanking.client.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.api.payment.v3.model.OBWriteDomestic2DataInitiationInstructedAmount;
+import com.transferwise.openbanking.client.json.JacksonJsonConverter;
+import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.security.KeySupplier;
 import com.transferwise.openbanking.client.test.TestAspspDetails;
 import com.transferwise.openbanking.client.test.TestKeyUtils;
@@ -32,7 +33,7 @@ class JwtClaimsSignerTest {
     private static KeyPair keyPair;
     private static X509Certificate certificate;
 
-    private static ObjectMapper objectMapper;
+    private static JsonConverter jsonConverter;
 
     private KeySupplier keySupplier;
 
@@ -42,14 +43,14 @@ class JwtClaimsSignerTest {
     static void initAll() throws Exception {
         keyPair = TestKeyUtils.aKeyPair();
         certificate = TestKeyUtils.aCertificate(keyPair);
-        objectMapper = new ObjectMapper();
+        jsonConverter = new JacksonJsonConverter();
     }
 
     @BeforeEach
     void init() {
         keySupplier = Mockito.mock(KeySupplier.class);
 
-        jwtClaimsSigner = new JwtClaimsSigner(keySupplier);
+        jwtClaimsSigner = new JwtClaimsSigner(keySupplier, jsonConverter);
     }
 
     @Test
@@ -65,7 +66,7 @@ class JwtClaimsSignerTest {
         JsonWebSignature jsonWebSignature = parseSignature(serialisedSignature);
 
         Assertions.assertEquals(expectedJwtClaims,
-            objectMapper.readValue(jsonWebSignature.getPayload(), Map.class));
+            jsonConverter.readValue(jsonWebSignature.getPayload(), Map.class));
         Assertions.assertEquals(aspspDetails.getSigningKeyId(), jsonWebSignature.getKeyIdHeaderValue());
     }
 
@@ -81,7 +82,7 @@ class JwtClaimsSignerTest {
         JsonWebSignature jsonWebSignature = parseSignature(serialisedSignature);
 
         Assertions.assertEquals(expectedJwtClaims,
-            objectMapper.readValue(jsonWebSignature.getPayload(), Map.class));
+            jsonConverter.readValue(jsonWebSignature.getPayload(), Map.class));
         Assertions.assertEquals(aspspDetails.getSigningKeyId(), jsonWebSignature.getKeyIdHeaderValue());
     }
 
@@ -192,7 +193,7 @@ class JwtClaimsSignerTest {
         throws Exception {
         JsonWebSignature jsonWebSignature = new JsonWebSignature();
         jsonWebSignature.setCompactSerialization(serialisedSignature);
-        jsonWebSignature.setPayload(objectMapper.writeValueAsString(detachedPayload));
+        jsonWebSignature.setPayload(jsonConverter.writeValueAsString(detachedPayload));
         jsonWebSignature.setKey(keyPair.getPublic());
         jsonWebSignature.setAlgorithmConstraints(PS256_ALGORITHM);
         jsonWebSignature.setKnownCriticalHeaders(HeaderParameterNames.BASE64URL_ENCODE_PAYLOAD,


### PR DESCRIPTION
## Context

Certain ASPSPs reject create payment consent and create payment requests when using the latest version of this library, because null fields in the requests are included in the serialised JSON values.  

## Changes

Introduce a new `JsonConverter` interface with a default implementation using the Jackson library, and use this for converting objects to JSON strings in the JWT claims signer and v3 REST payment client.

This is done to ensure that when serialising objects to JSON, null fields are not included in the serialised JSON, as some ASPSPs do not handle (ignore) null fields and reject requests containing these.

This was previously done by having the Jackson `@JsonInclude(JsonInclude.Include.NON_EMPTY)` annotation on the v3 payment domain classes, but the new generated model classes don't have these annotations.

I considered three ways to actually resolve this issue: 

1. Do nothing in this client library, the users of the library are instead responsible for ensuring the `RestTemplate` used for the V3 `PaymentClient` ignores null fields. This is not ideal as it's more hassle for the user of the library, likely not immediately an obvious requirement, and requires further changes when we switch to using `WebClient` instead of `RestTemplate`
2. Make the code generation include the `@JsonInclude(JsonInclude.Include.NON_EMPTY)` on classes it generates. I didn't go with this approach as it would likely be a bit complicated, involving Mustache template files, and making the Gradle build even more complex. 
3. The approach used in this PR. The advantage is that it doesn't get affected by the upcoming switch to `WebClient` and it's more obvious and clear how the JSON serialisation is done.