### PR TITLE
Payment API Response JSON Handling (PAYINP-951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2021-05-17
+### Changed
+- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the 
+  Jackson exception in a new `JsonReadException` class, and include the problematic JSON in the exception
+- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap 
+  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception  
+- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter` 
+  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this 
+  gives easy access to the full problematic JSON when  the response contains invalid JSON  
+
 ## [5.0.0] - 2021-04-20
 ### Added
 - A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.0.0
+version=5.1.0

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
@@ -62,14 +62,12 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
         log.info("Calling create payment consent API, with interaction ID {}", headers.getInteractionId());
 
-        OBWriteDomesticConsentResponse5 domesticPaymentConsentResponse;
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<OBWriteDomesticConsentResponse5> response = restOperations.exchange(
-                generateApiUrl(aspspDetails, PAYMENT_CONSENT_RESOURCE),
+            response = restOperations.exchange(generateApiUrl(aspspDetails, PAYMENT_CONSENT_RESOURCE),
                 HttpMethod.POST,
                 request,
-                OBWriteDomesticConsentResponse5.class);
-            domesticPaymentConsentResponse = response.getBody();
+                String.class);
         } catch (RestClientResponseException e) {
             throw new ApiCallException("Call to create payment consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
                 e);
@@ -77,6 +75,8 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
             throw new ApiCallException("Call to create payment consent endpoint failed, and no response body returned", e);
         }
 
+        OBWriteDomesticConsentResponse5 domesticPaymentConsentResponse = jsonConverter.readValue(response.getBody(),
+            OBWriteDomesticConsentResponse5.class);
         validateResponse(domesticPaymentConsentResponse);
 
         return domesticPaymentConsentResponse;
@@ -99,14 +99,13 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
         log.info("Calling submit payment API, with interaction ID {}", headers.getInteractionId());
 
-        OBWriteDomesticResponse5 domesticPaymentResponse;
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<OBWriteDomesticResponse5> response = restOperations.exchange(
+            response = restOperations.exchange(
                 generateApiUrl(aspspDetails, PAYMENT_RESOURCE),
                 HttpMethod.POST,
                 request,
-                OBWriteDomesticResponse5.class);
-            domesticPaymentResponse = response.getBody();
+                String.class);
         } catch (RestClientResponseException e) {
             throw new ApiCallException("Call to submit payment endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
                 e);
@@ -114,6 +113,8 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
             throw new ApiCallException("Call to submit payment endpoint failed, and no response body returned", e);
         }
 
+        OBWriteDomesticResponse5 domesticPaymentResponse = jsonConverter.readValue(response.getBody(),
+            OBWriteDomesticResponse5.class);
         validateResponse(domesticPaymentResponse);
 
         return domesticPaymentResponse;
@@ -129,15 +130,14 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
         log.info("Calling get payment consent API, with interaction ID {}", headers.getInteractionId());
 
-        OBWriteDomesticConsentResponse5 domesticPaymentConsentResponse;
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<OBWriteDomesticConsentResponse5> response = restOperations.exchange(
+            response = restOperations.exchange(
                 generateApiUrl(aspspDetails, PAYMENT_CONSENT_RESOURCE) + "/{consentId}",
                 HttpMethod.GET,
                 request,
-                OBWriteDomesticConsentResponse5.class,
+                String.class,
                 consentId);
-            domesticPaymentConsentResponse = response.getBody();
         } catch (RestClientResponseException e) {
             throw new ApiCallException("Call to get payment consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
                 e);
@@ -145,6 +145,8 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
             throw new ApiCallException("Call to get payment consent endpoint failed, and no response body returned", e);
         }
 
+        OBWriteDomesticConsentResponse5 domesticPaymentConsentResponse = jsonConverter.readValue(response.getBody(),
+            OBWriteDomesticConsentResponse5.class);
         validateResponse(domesticPaymentConsentResponse);
 
         return domesticPaymentConsentResponse;
@@ -160,15 +162,14 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
         log.info("Calling get payment API, with interaction ID {}", headers.getInteractionId());
 
-        OBWriteDomesticResponse5 domesticPaymentResponse;
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<OBWriteDomesticResponse5> response = restOperations.exchange(
+            response = restOperations.exchange(
                 generateApiUrl(aspspDetails, PAYMENT_RESOURCE) + "/{domesticPaymentId}",
                 HttpMethod.GET,
                 request,
-                OBWriteDomesticResponse5.class,
+                String.class,
                 domesticPaymentId);
-            domesticPaymentResponse = response.getBody();
         } catch (RestClientResponseException e) {
             throw new ApiCallException("Call to get payment endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
                 e);
@@ -176,6 +177,8 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
             throw new ApiCallException("Call to get payment endpoint failed, and no response body returned", e);
         }
 
+        OBWriteDomesticResponse5 domesticPaymentResponse = jsonConverter.readValue(response.getBody(),
+            OBWriteDomesticResponse5.class);
         validateResponse(domesticPaymentResponse);
 
         return domesticPaymentResponse;
@@ -193,15 +196,14 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
 
         log.info("Calling get confirmation of funds API, with interaction ID {}", headers.getInteractionId());
 
-        OBWriteFundsConfirmationResponse1 fundsConfirmationResponse;
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<OBWriteFundsConfirmationResponse1> response = restOperations.exchange(
+            response = restOperations.exchange(
                 generateApiUrl(aspspDetails, PAYMENT_CONSENT_RESOURCE) + "/{consentId}/funds-confirmation",
                 HttpMethod.GET,
                 request,
-                OBWriteFundsConfirmationResponse1.class,
+                String.class,
                 consentId);
-            fundsConfirmationResponse = response.getBody();
         } catch (RestClientResponseException e) {
             throw new ApiCallException("Call to get confirmation of funds endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
                 e);
@@ -210,6 +212,8 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                 e);
         }
 
+        OBWriteFundsConfirmationResponse1 fundsConfirmationResponse = jsonConverter.readValue(response.getBody(),
+            OBWriteFundsConfirmationResponse1.class);
         validateResponse(fundsConfirmationResponse);
 
         return fundsConfirmationResponse;

--- a/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.transferwise.openbanking.client.error.ClientException;
 
 /**
  * Implementation of the {@link JsonConverter} interface, using the Jackson library for JSON operations.
@@ -34,7 +33,7 @@ public class JacksonJsonConverter implements JsonConverter {
         try {
             return objectMapper.writeValueAsString(value);
         } catch (JsonProcessingException e) {
-            throw new ClientException("Unable to serialize object to JSON string", e);
+            throw new JsonWriteException("Unable to write object to JSON string", e, value);
         }
     }
 
@@ -43,7 +42,9 @@ public class JacksonJsonConverter implements JsonConverter {
         try {
             return objectMapper.readValue(content, valueType);
         } catch (JsonProcessingException e) {
-            throw new ClientException("Unable to read JSON string to object", e);
+            throw new JsonReadException("Unable to read JSON string to " + valueType.getSimpleName() + " object",
+                e,
+                content);
         }
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/json/JsonConverter.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JsonConverter.java
@@ -10,6 +10,7 @@ public interface JsonConverter {
      *
      * @param value The object to serialize
      * @return The serialized JSON string
+     * @throws JsonWriteException if there was a problem writing the object to JSON
      */
     String writeValueAsString(Object value);
 
@@ -20,6 +21,7 @@ public interface JsonConverter {
      * @param valueType The class type to de-serialize to
      * @param <T> The type to de-serialize to
      * @return The de-serialized JSON object
+     * @throws JsonReadException if there was a problem reading the JSON to an object
      */
     <T> T readValue(String content, Class<T> valueType);
 }

--- a/src/main/java/com/transferwise/openbanking/client/json/JsonReadException.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JsonReadException.java
@@ -1,0 +1,28 @@
+package com.transferwise.openbanking.client.json;
+
+import com.transferwise.openbanking.client.error.ClientException;
+
+/**
+ * Indicates there was a problem reading a JSON string to a Java object.
+ */
+public class JsonReadException extends ClientException {
+
+    /**
+     * The JSON string that was attempted to be read.
+     */
+    private final String json;
+
+    public JsonReadException(String message, String json) {
+        super(message);
+        this.json = json;
+    }
+
+    public JsonReadException(String message, Throwable cause, String json) {
+        super(message, cause);
+        this.json = json;
+    }
+
+    public String getJson() {
+        return json;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/json/JsonWriteException.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JsonWriteException.java
@@ -1,0 +1,28 @@
+package com.transferwise.openbanking.client.json;
+
+import com.transferwise.openbanking.client.error.ClientException;
+
+/**
+ * Indicates there was a problem writing an objet to a JSON string.
+ */
+public class JsonWriteException extends ClientException {
+
+    /**
+     * The Java object that was attempted to be written.
+     */
+    private final Object value;
+
+    public JsonWriteException(String message, Object value) {
+        super(message);
+        this.value = value;
+    }
+
+    public JsonWriteException(String message, Throwable cause, Object value) {
+        super(message, cause);
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+}

--- a/src/test/java/com/transferwise/openbanking/client/json/JacksonJsonConverterTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/json/JacksonJsonConverterTest.java
@@ -36,4 +36,14 @@ class JacksonJsonConverterTest {
         Assertions.assertEquals("Wise", object.getName());
         Assertions.assertNull(object.getSchemeName());
     }
+
+    @Test
+    void readValueThrowsJsonReadExceptionOnJacksonException() {
+        String json = "ABC";
+
+        JsonReadException thrown = Assertions.assertThrows(JsonReadException.class,
+            () -> jsonConverter.readValue(json, OBWriteDomestic2DataInitiationDebtorAccount.class));
+
+        Assertions.assertEquals("ABC", thrown.getJson());
+    }
 }


### PR DESCRIPTION
## Context

For some ASPSPs we are seeing JSON de-serialization exceptions when calling their confirmation of funds API, unfortunately the (Jackson) exception raised does not contain enough information to understand how the JSON is invalid.

A snippet of an example stack trace is given below to highlight this. 

```
Caused by: org.springframework.web.client.RestClientException: Error while extracting response for type [class com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1] and content type [application/json;charset=UTF-8]; nested exception is org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token; nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token
 at [Source: (PushbackInputStream); line: 1, column: 130] (through reference chain: com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1["Data"]->com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1Data["SupplementaryData"])
	at org.springframework.web.client.HttpMessageConverterExtractor.extractData(HttpMessageConverterExtractor.java:120)
	at org.springframework.web.client.RestTemplate$ResponseEntityResponseExtractor.extractData(RestTemplate.java:1037)
	at org.springframework.web.client.RestTemplate$ResponseEntityResponseExtractor.extractData(RestTemplate.java:1020)
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:778)
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:711)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:602)
	at com.transferwise.openbanking.client.api.payment.v3.RestPaymentClient.getFundsConfirmation(RestPaymentClient.java:198)
	... 175 common frames omitted
Caused by: org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token; nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token
 at [Source: (PushbackInputStream); line: 1, column: 130] (through reference chain: com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1["Data"]->com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1Data["SupplementaryData"])
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:389)
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.read(AbstractJackson2HttpMessageConverter.java:342)
	at org.springframework.web.client.HttpMessageConverterExtractor.extractData(HttpMessageConverterExtractor.java:105)
	... 181 common frames omitted
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token
 at [Source: (PushbackInputStream); line: 1, column: 130] (through reference chain: com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1["Data"]->com.transferwise.openbanking.client.api.payment.v3.model.OBWriteFundsConfirmationResponse1Data["SupplementaryData"])
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1468)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1242)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1148)
	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:63)
	at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:10)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:371)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:164)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:371)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:164)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4526)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3521)
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:378)
	... 183 common frames omitted
```

## Changes

This commit addresses this, by including the JSON string in the exception message when de-serializing JSON via the `JacksonJsonConverter` class, and ensuring we use this class to do the API response de-serialization.