### PR TITLE
Supplementary Data Model Field (PAYINP-951) & Client Registration Customisation (PAYINP-952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2021-05-18
+### Added
+- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client 
+  registration requests, to allow easier customisation of this value per ASPSP. By default, 
+  `getRegistrationTransportCertificateSubjectName` returns the certificate subject name in RFC 2253 format
+- The `AspspDetails` interface has a new method to return the scopes to request for an access token to use for an
+  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns 
+  the `openid` scope along with whatever scopes are configured for the software statement
+### Changed
+- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new 
+  `getRegistrationAuthenticationScopes` method should be used instead to customise this behaviour
+- Change the type of the `OBSupplementaryData1` model from a string to an object, to prevent JSON de-serialization
+  errors when parsing a JSON string with an empty object value (`{}`) for the supplementary data field.
+- Update the versions of various dependencies and plugins in the Gradle build configuration
+
 ## [5.1.0] - 2021-05-17
 ### Changed
 - When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id 'java-library'
     id 'checkstyle'
     id 'pmd'
-    id 'com.github.spotbugs' version '4.7.0'
+    id 'com.github.spotbugs' version '4.7.1'
     id 'org.hidetake.swagger.generator' version '2.18.2'
-    id "com.diffplug.spotless" version "5.12.1"
+    id "com.diffplug.spotless" version "5.12.5"
 }
 
 ext.projectName = "Openbanking client"
@@ -46,7 +46,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${libs.jackson}")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${libs.jackson}")
 
-    api('org.bitbucket.b_c:jose4j:0.7.6')
+    api('org.bitbucket.b_c:jose4j:0.7.7')
 
     compileOnly("org.projectlombok:lombok:${libs.lombok}")
     testCompileOnly("org.projectlombok:lombok:${libs.lombok}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=5.1.0
+version=6.0.0

--- a/specs/payment-initiation-v3-swagger.yaml
+++ b/specs/payment-initiation-v3-swagger.yaml
@@ -2628,7 +2628,7 @@ definitions:
             type: string
             pattern: '^[A-Z]{2,2}$'
   OBSupplementaryData1:
-    type: string
+    type: object
     properties: {}
     additionalProperties: true
     description: Additional information that can not be captured in the structured fields and/or any other specific block.

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -104,7 +104,7 @@ public class RegistrationRequestService {
     private String getTransportCertificateSubjectName(AspspDetails aspspDetails) {
         Certificate transportCertificate = keySupplier.getTransportCertificate(aspspDetails);
         if (transportCertificate instanceof X509Certificate) {
-            return ((X509Certificate) transportCertificate).getSubjectX500Principal().getName();
+            return aspspDetails.getRegistrationTransportCertificateSubjectName((X509Certificate) transportCertificate);
         } else {
             throw new ClientException("Supplied transport certificate is not an X509 certificate, cannot determine " +
                 "transport certificate subject name");

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -22,9 +22,7 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestOperations;
 
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -131,19 +129,8 @@ public class RestRegistrationClient implements RegistrationClient {
     }
 
     private String generateScopeValue(AspspDetails aspspDetails, SoftwareStatementDetails softwareStatementDetails) {
-        // The spec states a scope value isn't strictly needed, but some ASPSPs do actually require it, additionally
-        // some require the scope to contain `openid` but some require it to not contain `openid`. As we request a
-        // scope of what the permissions the software statement details currently has, we don't really support updating
-        // the permissions of a client registration, but as this can't be modified in the Open Banking directory this
-        // shouldn't be an issue.
-        Set<RegistrationPermission> permissions = new LinkedHashSet<>(softwareStatementDetails.getPermissions());
-        if (aspspDetails.registrationAuthenticationRequiresOpenIdScope()) {
-            permissions.add(RegistrationPermission.OPENID);
-        } else {
-            permissions.remove(RegistrationPermission.OPENID);
-        }
-
-        return permissions.stream()
+        return aspspDetails.getRegistrationAuthenticationScopes(softwareStatementDetails)
+            .stream()
             .map(RegistrationPermission::getValue)
             .collect(Collectors.joining(" "));
     }

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -6,6 +6,8 @@ import com.transferwise.openbanking.client.oauth.domain.GrantType;
 import com.transferwise.openbanking.client.oauth.domain.ResponseType;
 import org.jose4j.jws.AlgorithmIdentifiers;
 
+import javax.security.auth.x500.X500Principal;
+import java.security.cert.X509Certificate;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -111,6 +113,21 @@ public interface AspspDetails {
         // directory this shouldn't be an issue.
         permissions.addAll(softwareStatementDetails.getPermissions());
         return permissions;
+    }
+
+    /**
+     * Get the subject distinguished name of the given transport certificate, to use as the subject distinguished name
+     * claim in a registration request, when using TLS client authentication.
+     *
+     * <p>Some ASPSPs require this value to be in a specific format.
+     *
+     * <p>By default this returns the certificate subject distinguished name, in the RFC 2253 format.
+     *
+     * @param certificate the transport certificate being used for the client registration request
+     * @return the certificate subject name
+     */
+    default String getRegistrationTransportCertificateSubjectName(X509Certificate certificate) {
+        return certificate.getSubjectX500Principal().getName(X500Principal.RFC2253);
     }
 
     /**

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
@@ -40,7 +40,7 @@ public class GetAccessTokenRequest {
     }
 
     public GetAccessTokenRequest setGrantType(String grantType) {
-        requestBody.put(GRANT_TYPE_PARAM, grantType);
+        setBodyParameter(GRANT_TYPE_PARAM, grantType);
         return this;
     }
 
@@ -49,12 +49,12 @@ public class GetAccessTokenRequest {
     }
 
     public GetAccessTokenRequest setScope(String scope) {
-        requestBody.put(SCOPE_PARAM, scope);
+        setBodyParameter(SCOPE_PARAM, scope);
         return this;
     }
 
     public GetAccessTokenRequest setAuthorisationCode(String authorisationCode) {
-        requestBody.put(CODE_PARAM, authorisationCode);
+        setBodyParameter(CODE_PARAM, authorisationCode);
         return this;
     }
 
@@ -63,27 +63,27 @@ public class GetAccessTokenRequest {
     }
 
     public GetAccessTokenRequest setRedirectUri(String redirectUri) {
-        requestBody.put(REDIRECT_URI_PARAM, redirectUri);
+        setBodyParameter(REDIRECT_URI_PARAM, redirectUri);
         return this;
     }
 
     public GetAccessTokenRequest setClientId(String clientId) {
-        requestBody.put(CLIENT_ID_PARAM, clientId);
+        setBodyParameter(CLIENT_ID_PARAM, clientId);
         return this;
     }
 
     public GetAccessTokenRequest setClientSecret(String clientSecret) {
-        requestBody.put(CLIENT_SECRET_PARAM, clientSecret);
+        setBodyParameter(CLIENT_SECRET_PARAM, clientSecret);
         return this;
     }
 
     public GetAccessTokenRequest setClientAssertionType(String clientAssertionType) {
-        requestBody.put(CLIENT_ASSERTION_TYPE_PARAM, clientAssertionType);
+        setBodyParameter(CLIENT_ASSERTION_TYPE_PARAM, clientAssertionType);
         return this;
     }
 
     public GetAccessTokenRequest setClientAssertion(String clientAssertion) {
-        requestBody.put(CLIENT_ASSERTION_PARAM, clientAssertion);
+        setBodyParameter(CLIENT_ASSERTION_PARAM, clientAssertion);
         return this;
     }
 
@@ -98,5 +98,11 @@ public class GetAccessTokenRequest {
 
     public FapiHeaders getRequestHeaders() {
         return requestHeaders;
+    }
+
+    private void setBodyParameter(String key, String value) {
+        if (value != null && !value.isBlank()) {
+            requestBody.put(key, value);
+        }
     }
 }

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.web.client.response.MockRestResponseCreators;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -350,7 +351,9 @@ class RestRegistrationClientTest {
     private static Stream<Arguments> argumentsForAuthenticationScopeTest() {
         return Stream.of(
             Arguments.of(Set.of(RegistrationPermission.PAYMENTS), "payments"),
-            Arguments.of(Set.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS), "openid payments"),
+            Arguments.of(
+                new LinkedHashSet<>(List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS)),
+                "openid payments"),
             Arguments.of(Set.of(), null)
         );
     }

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -32,6 +32,8 @@ import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
@@ -229,14 +231,13 @@ class RestRegistrationClientTest {
 
     @ParameterizedTest
     @MethodSource("argumentsForAuthenticationScopeTest")
-    void updateRegistrationSupportsDifferentAuthenticationScopes(boolean registrationAuthenticationRequiresOpenIdScope,
-                                                                 List<RegistrationPermission> tppPermissions,
+    void updateRegistrationSupportsDifferentAuthenticationScopes(Set<RegistrationPermission> registrationAuthenticationScopes,
                                                                  String expectedAuthenticationScope)
         throws Exception {
 
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
-        AspspDetails aspspDetails = aAspspDefinition(false, registrationAuthenticationRequiresOpenIdScope);
-        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails(tppPermissions);
+        AspspDetails aspspDetails = aAspspDefinition(false, registrationAuthenticationScopes);
+        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
         AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
             .accessToken("access-token")
@@ -245,7 +246,7 @@ class RestRegistrationClientTest {
             .when(oAuthClient.getAccessToken(
                 Mockito.argThat(request ->
                     "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
-                        expectedAuthenticationScope.equals(request.getRequestBody().get("scope"))),
+                        Objects.equals(expectedAuthenticationScope, request.getRequestBody().get("scope"))),
                 Mockito.eq(aspspDetails)))
             .thenReturn(mockAccessTokenResponse);
 
@@ -309,6 +310,7 @@ class RestRegistrationClientTest {
     private static AspspDetails aAspspDefinition() {
         return TestAspspDetails.builder()
             .registrationUrl("/registration-url")
+            .registrationAuthenticationScopes(Set.of(RegistrationPermission.PAYMENTS))
             .clientId("client-id")
             .build();
     }
@@ -317,16 +319,17 @@ class RestRegistrationClientTest {
         return TestAspspDetails.builder()
             .registrationUrl("/registration-url")
             .registrationUsesJoseContentType(registrationUsesJoseContentType)
+            .registrationAuthenticationScopes(Set.of(RegistrationPermission.PAYMENTS))
             .clientId("client-id")
             .build();
     }
 
     private static AspspDetails aAspspDefinition(boolean registrationUsesJoseContentType,
-                                                 boolean registrationAuthenticationRequiresOpenIdScope) {
+                                                 Set<RegistrationPermission> registrationAuthenticationScopes) {
         return TestAspspDetails.builder()
             .registrationUrl("/registration-url")
             .registrationUsesJoseContentType(registrationUsesJoseContentType)
-            .registrationAuthenticationRequiresOpenIdScope(registrationAuthenticationRequiresOpenIdScope)
+            .registrationAuthenticationScopes(registrationAuthenticationScopes)
             .clientId("client-id")
             .build();
     }
@@ -334,12 +337,6 @@ class RestRegistrationClientTest {
     private static SoftwareStatementDetails aSoftwareStatementDetails() {
         return SoftwareStatementDetails.builder()
             .permissions(List.of(RegistrationPermission.PAYMENTS))
-            .build();
-    }
-
-    private static SoftwareStatementDetails aSoftwareStatementDetails(List<RegistrationPermission> permissions) {
-        return SoftwareStatementDetails.builder()
-            .permissions(permissions)
             .build();
     }
 
@@ -352,12 +349,9 @@ class RestRegistrationClientTest {
 
     private static Stream<Arguments> argumentsForAuthenticationScopeTest() {
         return Stream.of(
-            Arguments.of(false, List.of(RegistrationPermission.PAYMENTS), "payments"),
-            Arguments.of(false, List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS), "payments"),
-            Arguments.of(true, List.of(RegistrationPermission.PAYMENTS), "payments openid"),
-            Arguments.of(true,
-                List.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS),
-                "openid payments")
+            Arguments.of(Set.of(RegistrationPermission.PAYMENTS), "payments"),
+            Arguments.of(Set.of(RegistrationPermission.OPENID, RegistrationPermission.PAYMENTS), "openid payments"),
+            Arguments.of(Set.of(), null)
         );
     }
 }

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetails.java
@@ -1,5 +1,6 @@
 package com.transferwise.openbanking.client.test;
 
+import com.transferwise.openbanking.client.api.registration.domain.RegistrationPermission;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
@@ -9,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Set;
 
 @Data
 @Builder
@@ -20,6 +22,7 @@ public class TestAspspDetails implements AspspDetails {
     private String registrationUrl;
     private String registrationAudience;
     private String registrationIssuer;
+    private Set<RegistrationPermission> registrationAuthenticationScopes;
     private ClientAuthenticationMethod clientAuthenticationMethod;
     private String clientId;
     private String clientSecret;
@@ -32,7 +35,6 @@ public class TestAspspDetails implements AspspDetails {
     private boolean registrationUsesJoseContentType;
     private boolean detachedSignatureUsesDirectoryIssFormat;
     private boolean registrationRequiresLowerCaseJtiClaim;
-    private boolean registrationAuthenticationRequiresOpenIdScope;
 
     @Override
     public String getApiBaseUrl(String majorVersion, String resource) {
@@ -42,6 +44,11 @@ public class TestAspspDetails implements AspspDetails {
     @Override
     public String getRegistrationIssuer(SoftwareStatementDetails softwareStatementDetails) {
         return registrationIssuer;
+    }
+
+    @Override
+    public Set<RegistrationPermission> getRegistrationAuthenticationScopes(SoftwareStatementDetails softwareStatementDetails) {
+        return registrationAuthenticationScopes;
     }
 
     @Override
@@ -57,10 +64,5 @@ public class TestAspspDetails implements AspspDetails {
     @Override
     public boolean registrationRequiresLowerCaseJtiClaim() {
         return registrationRequiresLowerCaseJtiClaim;
-    }
-
-    @Override
-    public boolean registrationAuthenticationRequiresOpenIdScope() {
-        return registrationAuthenticationRequiresOpenIdScope;
     }
 }


### PR DESCRIPTION
## Context

This release includes two main changes, I've rolled them into one single PR as the individual changes are fairly small and it avoids doing multiple releases, one right after another. 

### Supplementary Data Model Field

With the previous [PR](https://github.com/transferwise/openbanking-client/pull/32) we can now see exactly why we were getting that Jackson processing exception. The issue relates to how we have changed the type of the `OBSupplementaryData1` in the Open Banking model definition from an object type to a string type. 

### Client Registration Customisation

To support Nationwide's recent changes to their client registration API, we need to support more customisation of the following behaviour when updating a client registration. 

- The scope of the access token requested for the authenticated call to the registration API
- The transport certificate subject name for use in the registration request

## Changes

See individual commits for details. 