### PR TITLE
Registration Client Refactoring (PAYINP-962)

### DIFF
--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
@@ -1,7 +1,9 @@
 package com.transferwise.openbanking.client.api.registration;
 
+import com.transferwise.openbanking.client.api.common.ApiResponse;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
+import com.transferwise.openbanking.client.api.registration.domain.ErrorResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 
@@ -15,27 +17,30 @@ public interface RegistrationClient {
      *
      * @param clientRegistrationRequest The details (JWT claims) of the registration request
      * @param aspspDetails              The details of the ASPSP to send the request to
-     * @return The response body from the ASPSP, containing the details of the registration
-     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
-     *                                                                   to the ASPSP or the HTTP call to the ASPSP
-     *                                                                   failed
+     * @return The response, from the ASPSP, to the client registration request
+     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request to
+     *                                                                   to the ASPSP, or there was a problem parsing
+     *                                                                   the response when the API call succeeded
      */
-    ClientRegistrationResponse registerClient(ClientRegistrationRequest clientRegistrationRequest,
-                                              AspspDetails aspspDetails);
+    ApiResponse<ClientRegistrationResponse, ErrorResponse> registerClient(ClientRegistrationRequest clientRegistrationRequest,
+                                                                          AspspDetails aspspDetails);
 
     /**
      * Update an existing TPP client registration with an ASPSP.
      *
      * @param clientRegistrationRequest The details (JWT claims) of the new registration request, this MUST contain
      *                                  both the claims to change, and those which are unchanged
+     * @param clientCredentialsToken    The client credentials access token, obtained from the ASPSPs OAuth API, to
+     *                                  use for the authorization for this ASPSP API call
      * @param aspspDetails              The details of the ASPSP to send the request to
      * @param softwareStatementDetails  The details of the software statement that the ASPSP registration currently uses
-     * @return The response body from the ASPSP, containing the details of the updated registration
-     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
-     *                                                                   to the ASPSP or the HTTP call to the ASPSP
-     *                                                                   failed
+     * @return The response, from the ASPSP, to the update client registration request
+     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request to
+     *                                                                   to the ASPSP, or there was a problem parsing
+     *                                                                   the response when the API call succeeded
      */
-    ClientRegistrationResponse updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
-                                                  AspspDetails aspspDetails,
-                                                  SoftwareStatementDetails softwareStatementDetails);
+    ApiResponse<ClientRegistrationResponse, ErrorResponse> updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
+                                                                              String clientCredentialsToken,
+                                                                              AspspDetails aspspDetails,
+                                                                              SoftwareStatementDetails softwareStatementDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationRequestService.java
@@ -2,6 +2,7 @@ package com.transferwise.openbanking.client.api.registration;
 
 import com.transferwise.openbanking.client.api.registration.domain.ApplicationType;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
+import com.transferwise.openbanking.client.oauth.ScopeFormatter;
 import com.transferwise.openbanking.client.oauth.domain.Scope;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
@@ -16,7 +17,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class RegistrationRequestService {
@@ -96,9 +96,7 @@ public class RegistrationRequestService {
             permissions.addAll(softwareStatementDetails.getPermissions());
         }
 
-        return permissions.stream()
-            .map(Scope::getValue)
-            .collect(Collectors.joining(" "));
+        return ScopeFormatter.formatScopes(permissions);
     }
 
     private String getTransportCertificateSubjectName(AspspDetails aspspDetails) {

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -1,16 +1,14 @@
 package com.transferwise.openbanking.client.api.registration;
 
+import com.transferwise.openbanking.client.api.common.ApiResponse;
+import com.transferwise.openbanking.client.api.common.BaseClient;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
-import com.transferwise.openbanking.client.oauth.domain.Scope;
+import com.transferwise.openbanking.client.api.registration.domain.ErrorResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
-import com.transferwise.openbanking.client.error.ApiCallException;
+import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
-import com.transferwise.openbanking.client.oauth.OAuthClient;
-import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
-import com.transferwise.openbanking.client.oauth.domain.GetAccessTokenRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -23,19 +21,22 @@ import org.springframework.web.client.RestOperations;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 @Slf4j
-public class RestRegistrationClient implements RegistrationClient {
+public class RestRegistrationClient extends BaseClient implements RegistrationClient {
 
     private final JwtClaimsSigner jwtClaimsSigner;
-    private final OAuthClient oAuthClient;
-    private final RestOperations restTemplate;
+
+    protected RestRegistrationClient(RestOperations restOperations,
+                                     JsonConverter jsonConverter,
+                                     JwtClaimsSigner jwtClaimsSigner) {
+        super(restOperations, jsonConverter);
+        this.jwtClaimsSigner = jwtClaimsSigner;
+    }
 
     @Override
-    public ClientRegistrationResponse registerClient(ClientRegistrationRequest clientRegistrationRequest,
-                                                     AspspDetails aspspDetails) {
+    public ApiResponse<ClientRegistrationResponse, ErrorResponse> registerClient(ClientRegistrationRequest clientRegistrationRequest,
+                                                                                 AspspDetails aspspDetails) {
 
         HttpHeaders headers = new HttpHeaders();
         if (aspspDetails.registrationUsesJoseContentType()) {
@@ -55,30 +56,34 @@ public class RestRegistrationClient implements RegistrationClient {
             request.getHeaders(),
             request.getBody());
 
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<ClientRegistrationResponse> response = restTemplate.exchange(
-                aspspDetails.getRegistrationUrl(),
+            response = restOperations.exchange(aspspDetails.getRegistrationUrl(),
                 HttpMethod.POST,
                 request,
-                ClientRegistrationResponse.class);
+                String.class);
 
             log.debug("Received registration response with headers '{}' and body '{}'",
                 response.getHeaders(),
                 response.getBody());
-
-            return response.getBody();
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to register client endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            return mapClientExceptionWithResponse(e, ErrorResponse.class);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to register client endpoint failed, and no response body returned", e);
+            return mapClientException(e);
         }
+
+        ClientRegistrationResponse clientRegistrationResponse = jsonConverter.readValue(response.getBody(),
+            ClientRegistrationResponse.class);
+        return ApiResponse.success(response.getStatusCodeValue(), response.getBody(), clientRegistrationResponse);
     }
 
     @Override
-    public ClientRegistrationResponse updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
-                                                         AspspDetails aspspDetails,
-                                                         SoftwareStatementDetails softwareStatementDetails) {
+    public ApiResponse<ClientRegistrationResponse, ErrorResponse> updateRegistration(
+        ClientRegistrationRequest clientRegistrationRequest,
+        String clientCredentialsToken,
+        AspspDetails aspspDetails,
+        SoftwareStatementDetails softwareStatementDetails
+    ) {
 
         HttpHeaders headers = new HttpHeaders();
         if (aspspDetails.registrationUsesJoseContentType()) {
@@ -89,7 +94,7 @@ public class RestRegistrationClient implements RegistrationClient {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         // as we're using a raw String as the body type, we need to manually set the header
         headers.setAcceptCharset(List.of(StandardCharsets.UTF_8));
-        headers.setBearerAuth(getClientCredentialsToken(aspspDetails, softwareStatementDetails));
+        headers.setBearerAuth(clientCredentialsToken);
 
         String signedClaims = jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails);
         HttpEntity<String> request = new HttpEntity<>(signedClaims, headers);
@@ -99,39 +104,25 @@ public class RestRegistrationClient implements RegistrationClient {
             request.getHeaders(),
             request.getBody());
 
+        ResponseEntity<String> response;
         try {
-            ResponseEntity<ClientRegistrationResponse> response = restTemplate.exchange(
-                aspspDetails.getRegistrationUrl() + "/{clientId}",
+            response = restOperations.exchange(aspspDetails.getRegistrationUrl() + "/{clientId}",
                 HttpMethod.PUT,
                 request,
-                ClientRegistrationResponse.class,
+                String.class,
                 aspspDetails.getClientId());
 
             log.debug("Received update registration response with headers '{}' and body '{}'",
                 response.getHeaders(),
                 response.getBody());
-
-            return response.getBody();
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to update registration endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            return mapClientExceptionWithResponse(e, ErrorResponse.class);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to update registration endpoint failed, and no response body returned", e);
+            return mapClientException(e);
         }
-    }
 
-    private String getClientCredentialsToken(AspspDetails aspspDetails,
-                                             SoftwareStatementDetails softwareStatementDetails) {
-        String scope = generateScopeValue(aspspDetails, softwareStatementDetails);
-        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest(scope);
-        AccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
-        return accessTokenResponse.getAccessToken();
-    }
-
-    private String generateScopeValue(AspspDetails aspspDetails, SoftwareStatementDetails softwareStatementDetails) {
-        return aspspDetails.getRegistrationAuthenticationScopes(softwareStatementDetails)
-            .stream()
-            .map(Scope::getValue)
-            .collect(Collectors.joining(" "));
+        ClientRegistrationResponse clientRegistrationResponse = jsonConverter.readValue(response.getBody(),
+            ClientRegistrationResponse.class);
+        return ApiResponse.success(response.getStatusCodeValue(), response.getBody(), clientRegistrationResponse);
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ErrorResponse.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/domain/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.transferwise.openbanking.client.api.registration.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data structure for the structured error response from an ASPSP for the dynamic client registration endpoint.
+ *
+ * @see <a href="https://openbankinguk.github.io/dcr-docs-pub/v3.2/dynamic-client-registration.html#error-structure">API docs</a>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ErrorResponse {
+
+    private String error;
+    private String errorDescription;
+}

--- a/src/main/java/com/transferwise/openbanking/client/oauth/ScopeFormatter.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/ScopeFormatter.java
@@ -1,0 +1,24 @@
+package com.transferwise.openbanking.client.oauth;
+
+import com.transferwise.openbanking.client.oauth.domain.Scope;
+import lombok.experimental.UtilityClass;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class ScopeFormatter {
+
+    /**
+     * Format a list of scopes as a single space seperated string, according to the RFC6749 OAuth 2 standard.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">RFC6749</a>
+     * @param scopes The list of scopes to format
+     * @return The scopes formatted as a single string
+     */
+    public static String formatScopes(Collection<Scope> scopes) {
+        return scopes.stream()
+            .map(Scope::getValue)
+            .collect(Collectors.joining(" "));
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
@@ -1,9 +1,11 @@
 package com.transferwise.openbanking.client.oauth.domain;
 
+import com.transferwise.openbanking.client.oauth.ScopeFormatter;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.springframework.http.HttpHeaders;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +24,14 @@ public class GetAccessTokenRequest {
 
     private final Map<String, String> requestBody = new HashMap<>();
     private final FapiHeaders requestHeaders = FapiHeaders.defaultHeaders();
+
+    public static GetAccessTokenRequest clientCredentialsRequest(Collection<Scope> scopes) {
+        return clientCredentialsRequest(ScopeFormatter.formatScopes(scopes));
+    }
+
+    public static GetAccessTokenRequest clientCredentialsRequest(Scope scope) {
+        return clientCredentialsRequest(scope.getValue());
+    }
 
     public static GetAccessTokenRequest clientCredentialsRequest(String scope) {
         return new GetAccessTokenRequest()

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -1,15 +1,15 @@
 package com.transferwise.openbanking.client.api.registration;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.openbanking.client.api.common.ApiResponse;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationRequest;
 import com.transferwise.openbanking.client.api.registration.domain.ClientRegistrationResponse;
-import com.transferwise.openbanking.client.oauth.domain.Scope;
+import com.transferwise.openbanking.client.api.registration.domain.ErrorResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
-import com.transferwise.openbanking.client.error.ApiCallException;
+import com.transferwise.openbanking.client.json.JacksonJsonConverter;
+import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
-import com.transferwise.openbanking.client.oauth.OAuthClient;
-import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
+import com.transferwise.openbanking.client.oauth.domain.Scope;
 import com.transferwise.openbanking.client.test.TestAspspDetails;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,12 +28,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.client.match.MockRestRequestMatchers;
 import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -41,13 +40,10 @@ import java.util.stream.Stream;
 @SuppressWarnings({"PMD.UnusedPrivateMethod", "PMD.AvoidDuplicateLiterals"}) // PMD considers argumentsForRegisterClientTest unused
 class RestRegistrationClientTest {
 
-    private static ObjectMapper objectMapper;
+    private static JsonConverter jsonConverter;
 
     @Mock
     private JwtClaimsSigner jwtClaimsSigner;
-
-    @Mock
-    private OAuthClient oAuthClient;
 
     private MockRestServiceServer mockAspspServer;
 
@@ -55,7 +51,7 @@ class RestRegistrationClientTest {
 
     @BeforeAll
     static void initAll() {
-        objectMapper = new ObjectMapper();
+        jsonConverter = new JacksonJsonConverter();
     }
 
     @BeforeEach
@@ -63,12 +59,13 @@ class RestRegistrationClientTest {
         RestTemplate restTemplate = new RestTemplate();
         mockAspspServer = MockRestServiceServer.createServer(restTemplate);
 
-        restRegistrationClient = new RestRegistrationClient(jwtClaimsSigner, oAuthClient, restTemplate);
+        restRegistrationClient = new RestRegistrationClient(restTemplate, jsonConverter, jwtClaimsSigner);
     }
 
     @ParameterizedTest
     @MethodSource("argumentsForContentTypeTest")
-    void registerClient(boolean registrationUsesJoseContentType, String expectedContentType) throws Exception {
+    void registerClientReturnsSuccessResponseOnApiCallSuccess(boolean registrationUsesJoseContentType,
+                                                              String expectedContentType) {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
         AspspDetails aspspDetails = aAspspDefinition(registrationUsesJoseContentType);
 
@@ -80,7 +77,7 @@ class RestRegistrationClientTest {
             .clientId("client-id")
             .clientIdIssuedAt("100")
             .build();
-        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl()))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, expectedContentType))
@@ -90,11 +87,15 @@ class RestRegistrationClientTest {
             .andExpect(MockRestRequestMatchers.content().string(signedClaims))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        ClientRegistrationResponse registrationResponse = restRegistrationClient.registerClient(
+        ApiResponse<ClientRegistrationResponse, ErrorResponse> apiResponse = restRegistrationClient.registerClient(
             clientRegistrationRequest,
             aspspDetails);
 
-        Assertions.assertEquals(mockResponse, registrationResponse);
+        Assertions.assertFalse(apiResponse.isCallFailed());
+        Assertions.assertEquals(jsonResponse, apiResponse.getResponseBody());
+        Assertions.assertEquals(mockResponse, apiResponse.getSuccessResponseBody());
+        Assertions.assertNull(apiResponse.getFailureResponseBody());
+        Assertions.assertNull(apiResponse.getFailureException());
 
         mockAspspServer.verify();
     }
@@ -116,19 +117,21 @@ class RestRegistrationClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        ClientRegistrationResponse registrationResponse = restRegistrationClient.registerClient(
+        ApiResponse<ClientRegistrationResponse, ErrorResponse> apiResponse = restRegistrationClient.registerClient(
             clientRegistrationRequest,
             aspspDetails);
 
-        Assertions.assertEquals("2021-02-10T12:00:51.191+0000", registrationResponse.getClientIdIssuedAt());
+        Assertions.assertFalse(apiResponse.isCallFailed());
+        Assertions.assertEquals("2021-02-10T12:00:51.191+0000",
+            apiResponse.getSuccessResponseBody().getClientIdIssuedAt());
         Assertions.assertEquals("2022-02-10T12:00:51.191+0000",
-            registrationResponse.getClientSecretExpiresAt());
+            apiResponse.getSuccessResponseBody().getClientSecretExpiresAt());
 
         mockAspspServer.verify();
     }
 
     @Test
-    void registerClientThrowsApiCallExceptionOnApiCallFailure() {
+    void registerClientReturnsFailureResponseOnApiCallFailure() {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
         AspspDetails aspspDetails = aAspspDefinition();
 
@@ -138,30 +141,30 @@ class RestRegistrationClientTest {
 
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl()))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
-            .andRespond(MockRestResponseCreators.withServerError());
+            .andRespond(MockRestResponseCreators.withServerError().body("internal server error"));
 
-        Assertions.assertThrows(ApiCallException.class,
-            () -> restRegistrationClient.registerClient(clientRegistrationRequest, aspspDetails));
+        ApiResponse<ClientRegistrationResponse, ErrorResponse> apiResponse = restRegistrationClient.registerClient(
+            clientRegistrationRequest,
+            aspspDetails);
+
+        Assertions.assertTrue(apiResponse.isCallFailed());
+        Assertions.assertEquals(500, apiResponse.getStatusCode());
+        Assertions.assertEquals("internal server error", apiResponse.getResponseBody());
+        Assertions.assertNull(apiResponse.getSuccessResponseBody());
+        Assertions.assertNull(apiResponse.getFailureResponseBody());
+        Assertions.assertTrue(apiResponse.getFailureException() instanceof HttpServerErrorException.InternalServerError);
+        Assertions.assertFalse(apiResponse.isClientErrorResponse());
+        Assertions.assertTrue(apiResponse.isServerErrorResponse());
 
         mockAspspServer.verify();
     }
 
     @Test
-    void updateRegistration() throws Exception {
+    void updateRegistrationReturnsSuccessResponseOnApiCallSuccess() {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
+        String clientCredentialsToken = "client-credentials-token";
         AspspDetails aspspDetails = aAspspDefinition();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-
-        AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
-            .accessToken("access-token")
-            .build();
-        Mockito
-            .when(oAuthClient.getAccessToken(
-                Mockito.argThat(request ->
-                    "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
-                        "payments".equals(request.getRequestBody().get("scope"))),
-                Mockito.eq(aspspDetails)))
-            .thenReturn(mockAccessTokenResponse);
 
         String signedClaims = "signed-claims";
         Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
@@ -170,23 +173,28 @@ class RestRegistrationClientTest {
         ClientRegistrationResponse mockResponse = ClientRegistrationResponse.builder()
             .clientId("client-id")
             .build();
-        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, "application/jwt"))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT_CHARSET,
                 StandardCharsets.UTF_8.name().toLowerCase()))
-            .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer access-token"))
+            .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + clientCredentialsToken))
             .andExpect(MockRestRequestMatchers.content().string(signedClaims))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
+        ApiResponse<ClientRegistrationResponse, ErrorResponse> apiResponse = restRegistrationClient.updateRegistration(
             clientRegistrationRequest,
+            clientCredentialsToken,
             aspspDetails,
             softwareStatementDetails);
 
-        Assertions.assertEquals(mockResponse, registrationResponse);
+        Assertions.assertFalse(apiResponse.isCallFailed());
+        Assertions.assertEquals(jsonResponse, apiResponse.getResponseBody());
+        Assertions.assertEquals(mockResponse, apiResponse.getSuccessResponseBody());
+        Assertions.assertNull(apiResponse.getFailureResponseBody());
+        Assertions.assertNull(apiResponse.getFailureException());
 
         mockAspspServer.verify();
     }
@@ -194,18 +202,12 @@ class RestRegistrationClientTest {
     @ParameterizedTest
     @MethodSource("argumentsForContentTypeTest")
     void updateRegistrationSupportsDifferentContentTypes(boolean registrationUsesJoseContentType,
-                                                         String expectedContentType)
-        throws Exception {
+                                                         String expectedContentType) {
 
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
+        String clientCredentialsToken = "client-credentials-token";
         AspspDetails aspspDetails = aAspspDefinition(registrationUsesJoseContentType);
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-
-        AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
-            .accessToken("access-token")
-            .build();
-        Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
-            .thenReturn(mockAccessTokenResponse);
 
         String signedClaims = "signed-claims";
         Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
@@ -214,90 +216,58 @@ class RestRegistrationClientTest {
         ClientRegistrationResponse mockResponse = ClientRegistrationResponse.builder()
             .clientId("client-id")
             .build();
-        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
+        String jsonResponse = jsonConverter.writeValueAsString(mockResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.CONTENT_TYPE, expectedContentType))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
+        ApiResponse<ClientRegistrationResponse, ErrorResponse> apiResponse = restRegistrationClient.updateRegistration(
             clientRegistrationRequest,
+            clientCredentialsToken,
             aspspDetails,
             softwareStatementDetails);
 
-        Assertions.assertEquals(mockResponse, registrationResponse);
-
-        mockAspspServer.verify();
-    }
-
-    @ParameterizedTest
-    @MethodSource("argumentsForAuthenticationScopeTest")
-    void updateRegistrationSupportsDifferentAuthenticationScopes(Set<Scope> registrationAuthenticationScopes,
-                                                                 String expectedAuthenticationScope)
-        throws Exception {
-
-        ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
-        AspspDetails aspspDetails = aAspspDefinition(false, registrationAuthenticationScopes);
-        SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-
-        AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
-            .accessToken("access-token")
-            .build();
-        Mockito
-            .when(oAuthClient.getAccessToken(
-                Mockito.argThat(request ->
-                    "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
-                        Objects.equals(expectedAuthenticationScope, request.getRequestBody().get("scope"))),
-                Mockito.eq(aspspDetails)))
-            .thenReturn(mockAccessTokenResponse);
-
-        String signedClaims = "signed-claims";
-        Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
-            .thenReturn(signedClaims);
-
-        ClientRegistrationResponse mockResponse = ClientRegistrationResponse.builder()
-            .clientId("client-id")
-            .build();
-        String jsonResponse = objectMapper.writeValueAsString(mockResponse);
-        mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
-            .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
-            .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
-
-        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
-            clientRegistrationRequest,
-            aspspDetails,
-            softwareStatementDetails);
-
-        Assertions.assertEquals(mockResponse, registrationResponse);
+        Assertions.assertFalse(apiResponse.isCallFailed());
+        Assertions.assertEquals(jsonResponse, apiResponse.getResponseBody());
+        Assertions.assertEquals(mockResponse, apiResponse.getSuccessResponseBody());
+        Assertions.assertNull(apiResponse.getFailureResponseBody());
+        Assertions.assertNull(apiResponse.getFailureException());
 
         mockAspspServer.verify();
     }
 
     @Test
-    void updateRegistrationThrowsApiCallExceptionOnApiCallFailure() {
+    void updateRegistrationReturnsFailureResponseOnApiCallFailure() {
         ClientRegistrationRequest clientRegistrationRequest = aRegistrationClaims();
+        String clientCredentialsToken = "client-credentials-token";
         AspspDetails aspspDetails = aAspspDefinition();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-
-        AccessTokenResponse mockAccessTokenResponse = AccessTokenResponse.builder()
-            .accessToken("access-token")
-            .build();
-        Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
-            .thenReturn(mockAccessTokenResponse);
 
         String signedClaims = "signed-claims";
         Mockito.when(jwtClaimsSigner.createSignature(clientRegistrationRequest, aspspDetails))
             .thenReturn(signedClaims);
 
+        ErrorResponse mockErrorResponse = aErrorResponse();
+        String jsonResponse = jsonConverter.writeValueAsString(mockErrorResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(aspspDetails.getRegistrationUrl() + "/client-id"))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.PUT))
-            .andRespond(MockRestResponseCreators.withServerError());
+            .andRespond(MockRestResponseCreators.withServerError().body(jsonResponse));
 
-        Assertions.assertThrows(ApiCallException.class,
-            () -> restRegistrationClient.updateRegistration(
-                clientRegistrationRequest,
-                aspspDetails,
-                softwareStatementDetails));
+        ApiResponse<ClientRegistrationResponse, ErrorResponse> apiResponse = restRegistrationClient.updateRegistration(
+            clientRegistrationRequest,
+            clientCredentialsToken,
+            aspspDetails,
+            softwareStatementDetails);
+
+        Assertions.assertTrue(apiResponse.isCallFailed());
+        Assertions.assertEquals(500, apiResponse.getStatusCode());
+        Assertions.assertEquals(jsonResponse, apiResponse.getResponseBody());
+        Assertions.assertNull(apiResponse.getSuccessResponseBody());
+        Assertions.assertEquals(mockErrorResponse, apiResponse.getFailureResponseBody());
+        Assertions.assertTrue(apiResponse.getFailureException() instanceof HttpServerErrorException.InternalServerError);
+        Assertions.assertFalse(apiResponse.isClientErrorResponse());
+        Assertions.assertTrue(apiResponse.isServerErrorResponse());
 
         mockAspspServer.verify();
     }
@@ -325,19 +295,15 @@ class RestRegistrationClientTest {
             .build();
     }
 
-    private static AspspDetails aAspspDefinition(boolean registrationUsesJoseContentType,
-                                                 Set<Scope> registrationAuthenticationScopes) {
-        return TestAspspDetails.builder()
-            .registrationUrl("/registration-url")
-            .registrationUsesJoseContentType(registrationUsesJoseContentType)
-            .registrationAuthenticationScopes(registrationAuthenticationScopes)
-            .clientId("client-id")
-            .build();
-    }
-
     private static SoftwareStatementDetails aSoftwareStatementDetails() {
         return SoftwareStatementDetails.builder()
             .permissions(List.of(Scope.PAYMENTS))
+            .build();
+    }
+
+    private static ErrorResponse aErrorResponse() {
+        return ErrorResponse.builder()
+            .error("invalid request")
             .build();
     }
 
@@ -345,16 +311,6 @@ class RestRegistrationClientTest {
         return Stream.of(
             Arguments.of(false, "application/jwt"),
             Arguments.of(true, "application/jose")
-        );
-    }
-
-    private static Stream<Arguments> argumentsForAuthenticationScopeTest() {
-        return Stream.of(
-            Arguments.of(Set.of(Scope.PAYMENTS), "payments"),
-            Arguments.of(
-                new LinkedHashSet<>(List.of(Scope.OPENID, Scope.PAYMENTS)),
-                "openid payments"),
-            Arguments.of(Set.of(), null)
         );
     }
 }

--- a/src/test/java/com/transferwise/openbanking/client/oauth/ScopeFormatterTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/oauth/ScopeFormatterTest.java
@@ -1,0 +1,29 @@
+package com.transferwise.openbanking.client.oauth;
+
+import com.transferwise.openbanking.client.oauth.domain.Scope;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+@SuppressWarnings({"PMD.UnusedPrivateMethod"}) // PMD considers argumentsForFormatScopesTest unused
+class ScopeFormatterTest {
+
+    @ParameterizedTest
+    @MethodSource("argumentsForFormatScopesTest")
+    void formatScopes(Collection<Scope> scopes, String expectedFormattedValue) {
+        Assertions.assertEquals(expectedFormattedValue, ScopeFormatter.formatScopes(scopes));
+    }
+
+    private static Stream<Arguments> argumentsForFormatScopesTest() {
+        return Stream.of(
+            Arguments.of(List.of(), ""),
+            Arguments.of(List.of(Scope.PAYMENTS), "payments"),
+            Arguments.of(List.of(Scope.OPENID, Scope.PAYMENTS), "openid payments")
+        );
+    }
+}


### PR DESCRIPTION
## Context

Continuing with the work to provide callers with easy access to structured error responses, doing the same refactoring as was done for the payments client, to the registration client. 

## Changes

Refactor the registration client so that the OAuth access token to use for the update client registration API call to the ASPSP, is passed in by the caller rather than being fetched by the registration client internally.

Further refactor the registration client implementation so that when the API call fails because the ASPSP returned a non-successful response, we return a response wrapper that signals the call failed, rather than throwing an exception. This failure response wrapper contains the details of the response, the failure, and the parsed structured error response.

Also with the registration client no longer taking care of fetching the OAuth access token for the update client registration request, add functionality to make it easier to build the required get access token request.