### PR TITLE
OAuth Client Refactoring (PAYINP-962)

### DIFF
--- a/src/main/java/com/transferwise/openbanking/client/oauth/OAuthClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/OAuthClient.java
@@ -1,7 +1,9 @@
 package com.transferwise.openbanking.client.oauth;
 
+import com.transferwise.openbanking.client.api.common.ApiResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
+import com.transferwise.openbanking.client.oauth.domain.ErrorResponse;
 import com.transferwise.openbanking.client.oauth.domain.GetAccessTokenRequest;
 
 /**
@@ -14,10 +16,11 @@ public interface OAuthClient {
      *
      * @param getAccessTokenRequest The details of the token to get
      * @param aspspDetails          The details of the ASPSP to send the request to
-     * @return The result, from the ASPSP, of the access token request
-     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
-     *                                                                   to the ASPSP or the HTTP call to the ASPSP
-     *                                                                   failed
+     * @return The response, from the ASPSP, to the access token request
+     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request to
+     *                                                                   to the ASPSP, or there was a problem parsing
+     *                                                                   the response when the API call succeeded
      */
-    AccessTokenResponse getAccessToken(GetAccessTokenRequest getAccessTokenRequest, AspspDetails aspspDetails);
+    ApiResponse<AccessTokenResponse, ErrorResponse> getAccessToken(GetAccessTokenRequest getAccessTokenRequest,
+                                                                   AspspDetails aspspDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/ErrorResponse.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/ErrorResponse.java
@@ -1,0 +1,27 @@
+package com.transferwise.openbanking.client.oauth.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Data structure for the structured error response from an ASPSP for the OAuth access token endpoint.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.2">API docs</a>
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ErrorResponse {
+
+    private String error;
+    private String errorDescription;
+    private String errorUri;
+}


### PR DESCRIPTION
## Context

Continuing with the work to provide callers with easy access to structured error responses, doing the same refactoring as was done for the payments client, to the OAuth client.

## Changes

Refactor the OAuth client implementation so that when the API call fails because the ASPSP returned a non-successful response, we return a response wrapper that signals the call failed, rather than throwing an exception. This failure response wrapper contains the details of the response, the failure, and the parsed structured error response.

This follows the same refactoring done for the payment client, to give callers easy access to the parsed structured error response on API call failure.
