### PR TITLE
Delete Registration Endpoint (PAYINP-1080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2021-07-13
+### Added 
+- The `RegistrationClient` interface has a new method to call the delete client registration endpoint
+- The `GetAccessTokenRequest` class has new constructors to make it easier to supply the scope of the request
+### Changed
+- The `RegistrationPermission` class has been renamed to `Scope` and moved to the `oauth.domain` package, to better
+  correspond to what the class represents
+- Update the versions of various dependencies and plugins in the Gradle build configuration  
+
 ## [6.0.0] - 2021-05-18
 ### Added
 - The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.0.0
+version=7.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RegistrationClient.java
@@ -38,4 +38,15 @@ public interface RegistrationClient {
     ClientRegistrationResponse updateRegistration(ClientRegistrationRequest clientRegistrationRequest,
                                                   AspspDetails aspspDetails,
                                                   SoftwareStatementDetails softwareStatementDetails);
+
+    /**
+     * Delete an existing TPP client registration with an ASPSP.
+     *
+     * @param aspspDetails              The details of the ASPSP to send the request to
+     * @param softwareStatementDetails  The details of the software statement that the ASPSP registration currently uses
+     * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
+     *                                                                   to the ASPSP or the HTTP call to the ASPSP
+     *                                                                   failed
+     */
+    void deleteRegistration(AspspDetails aspspDetails, SoftwareStatementDetails softwareStatementDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -120,6 +120,37 @@ public class RestRegistrationClient implements RegistrationClient {
         }
     }
 
+    @Override
+    public void deleteRegistration(AspspDetails aspspDetails, SoftwareStatementDetails softwareStatementDetails) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(getClientCredentialsToken(aspspDetails, softwareStatementDetails));
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        log.debug("Sending delete registration request to '{}/{}' with headers '{}'",
+            aspspDetails.getRegistrationUrl(),
+            aspspDetails.getClientId(),
+            request.getHeaders());
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                aspspDetails.getRegistrationUrl() + "/{clientId}",
+                HttpMethod.DELETE,
+                request,
+                String.class,
+                aspspDetails.getClientId());
+
+            log.debug("Received delete registration response with headers '{}' and body '{}'",
+                response.getHeaders(),
+                response.getBody());
+        } catch (RestClientResponseException e) {
+            throw new ApiCallException("Call to delete registration endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e);
+        } catch (RestClientException e) {
+            throw new ApiCallException("Call to delete registration endpoint failed, and no response body returned", e);
+        }
+    }
+
     private String getClientCredentialsToken(AspspDetails aspspDetails,
                                              SoftwareStatementDetails softwareStatementDetails) {
         String scope = generateScopeValue(aspspDetails, softwareStatementDetails);


### PR DESCRIPTION
## Context

We need to call the delete client registration API for certain banks. 

## Changes

Extend the registration client to include support for calling the 'delete client registration' endpoint.

As we'll want to make use of this change right away, also update the changelog and version number so a new version can be published. 
