### PR TITLE
Allow different trust anchor for an ASPSP

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.1.1
+version=7.1.2

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -261,4 +261,15 @@ public interface AspspDetails {
     default boolean registrationRequiresLowerCaseJtiClaim() {
         return false;
     }
+
+
+    /**
+     * Get the URL to use as the trust anchor for the public key store,
+     * when using the private key JWT client authentication method.
+     *
+     * @return the Trust Anchor URL, defaults to the OBIE URL
+     */
+    default String getTrustAnchor() {
+        return "openbanking.org.uk";
+    }
 }

--- a/src/main/java/com/transferwise/openbanking/client/jwt/JwtClaimsSigner.java
+++ b/src/main/java/com/transferwise/openbanking/client/jwt/JwtClaimsSigner.java
@@ -23,7 +23,6 @@ import java.security.cert.X509Certificate;
 @RequiredArgsConstructor
 public class JwtClaimsSigner {
 
-    private static final String TRUST_ANCHOR_VALUE = "openbanking.org.uk";
 
     private static final String X509_CERTIFICATE_TYPE = "X.509";
 
@@ -77,7 +76,7 @@ public class JwtClaimsSigner {
         jsonWebSignature.setHeader(OpenBankingJwsHeaders.OPEN_BANKING_IAT, NumericDate.now().getValue());
         jsonWebSignature.setHeader(OpenBankingJwsHeaders.OPEN_BANKING_ISS,
             generateIssClaim(aspspDetails, softwareStatementDetails));
-        jsonWebSignature.setHeader(OpenBankingJwsHeaders.OPEN_BANKING_TAN, TRUST_ANCHOR_VALUE);
+        jsonWebSignature.setHeader(OpenBankingJwsHeaders.OPEN_BANKING_TAN, aspspDetails.getTrustAnchor());
 
         if (aspspDetails.detachedSignaturesRequireB64Header()) {
             jsonWebSignature.setHeader(HeaderParameterNames.BASE64URL_ENCODE_PAYLOAD, false);

--- a/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetailsWithDifferentTrustAnchor.java
+++ b/src/test/java/com/transferwise/openbanking/client/test/TestAspspDetailsWithDifferentTrustAnchor.java
@@ -1,0 +1,70 @@
+package com.transferwise.openbanking.client.test;
+
+import com.transferwise.openbanking.client.configuration.AspspDetails;
+import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
+import com.transferwise.openbanking.client.oauth.ClientAuthenticationMethod;
+import com.transferwise.openbanking.client.oauth.domain.GrantType;
+import com.transferwise.openbanking.client.oauth.domain.ResponseType;
+import com.transferwise.openbanking.client.oauth.domain.Scope;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Set;
+
+@Data
+@Builder
+public class TestAspspDetailsWithDifferentTrustAnchor implements AspspDetails {
+    private String internalId;
+    private String organisationId;
+    private String apiBaseUrl;
+    private String tokenUrl;
+    private String registrationUrl;
+    private String registrationAudience;
+    private String registrationIssuer;
+    private Set<Scope> registrationAuthenticationScopes;
+    private ClientAuthenticationMethod clientAuthenticationMethod;
+    private String clientId;
+    private String clientSecret;
+    private String privateKeyJwtAuthenticationAudience;
+    private String signingAlgorithm;
+    private String signingKeyId;
+    private List<GrantType> grantTypes;
+    private List<ResponseType> responseTypes;
+    private String paymentApiMinorVersion;
+    private boolean registrationUsesJoseContentType;
+    private boolean detachedSignatureUsesDirectoryIssFormat;
+    private boolean registrationRequiresLowerCaseJtiClaim;
+    private String trustAnchor;
+
+    @Override
+    public String getApiBaseUrl(String majorVersion, String resource) {
+        return apiBaseUrl;
+    }
+
+    @Override
+    public String getRegistrationIssuer(SoftwareStatementDetails softwareStatementDetails) {
+        return registrationIssuer;
+    }
+
+    @Override
+    public Set<Scope> getRegistrationAuthenticationScopes(SoftwareStatementDetails softwareStatementDetails) {
+        return registrationAuthenticationScopes;
+    }
+
+    @Override
+    public boolean registrationUsesJoseContentType() {
+        return registrationUsesJoseContentType;
+    }
+
+    @Override
+    public boolean detachedSignatureUsesDirectoryIssFormat() {
+        return detachedSignatureUsesDirectoryIssFormat;
+    }
+
+    @Override
+    public boolean registrationRequiresLowerCaseJtiClaim() {
+        return registrationRequiresLowerCaseJtiClaim;
+    }
+
+}


### PR DESCRIPTION
## Context

It is possible that an ASPSP will use a different trust anchor for the public keys for verifying JWT tokens. 

https://openbankinguk.github.io/read-write-api-site3/v3.1.9/profiles/read-write-data-api-profile.html#using-an-eidas-certificate-that-is-not-registered-with-a-trust-anchor
https://openbankinguk.github.io/read-write-api-site3/v3.1.9/profiles/read-write-data-api-profile.html#key-stores

## Changes

Added the ability for a different trust anchor to be defined through an implementation of AspspDetails by overriding the method AspspDetails.getTrustAnchor(), which will return the Open Banking directory by default 
