### PR TITLE
UKGROWTH-55 Use client_credenial grantype for domestic vrp payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.2] - 2021-11-19
+### Changed
+- use client_credential as for domestic_vrp_payment 
+
 ## [7.2.1] - 2021-11-19
 ### Changed
 - Make `RestVrpClient` constructor public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.2.2] - 2021-11-19
 ### Changed
-- use client_credential as for domestic_vrp_payment 
+- Use client_credential for domestic Vrp initiation and funds confirmation flows.
+ As both of them are not tied to the consent creation flow.      
 
 ## [7.2.1] - 2021-11-19
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.2.1
+version=7.2.2

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -1,6 +1,5 @@
 package com.transferwise.openbanking.client.api.vrp;
 
-import com.transferwise.openbanking.client.api.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.common.BasePaymentClient;
 import com.transferwise.openbanking.client.api.common.IdempotencyKeyGenerator;
 import com.transferwise.openbanking.client.api.common.OpenBankingHeaders;
@@ -96,12 +95,11 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
     public OBVRPFundsConfirmationResponse getFundsConfirmation(
         String consentId,
         OBVRPFundsConfirmationRequest fundsConfirmationRequest,
-        AuthorizationContext authorizationContext,
         AspspDetails aspspDetails
     ) {
         OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(
             aspspDetails.getOrganisationId(),
-            exchangeAuthorizationCode(authorizationContext, aspspDetails)
+            getClientCredentialsToken(aspspDetails)
         );
 
         String body = jsonConverter.writeValueAsString(fundsConfirmationRequest);
@@ -196,12 +194,11 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
     @Override
     public OBDomesticVRPResponse submitDomesticVrp(
         OBDomesticVRPRequest vrpRequest,
-        AuthorizationContext authorizationContext,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails
     ) {
         OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getOrganisationId(),
-            exchangeAuthorizationCode(authorizationContext, aspspDetails),
+            getClientCredentialsToken(aspspDetails),
             idempotencyKeyGenerator.generateKeyForSubmission(vrpRequest),
             jwtClaimsSigner.createDetachedSignature(vrpRequest, aspspDetails, softwareStatementDetails));
 

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
@@ -1,6 +1,5 @@
 package com.transferwise.openbanking.client.api.vrp;
 
-import com.transferwise.openbanking.client.api.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentRequest;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPDetails;
@@ -42,7 +41,6 @@ public interface VrpClient {
      *
      * @param consentId                     The ID of the domestic VRP consent to get the details of
      * @param obVRPFundsConfirmationRequest The details of the VRP funds confirmation request
-     * @param authorizationContext          The successful consent authorisation data
      * @param aspspDetails                  The details of the ASPSP to send the request to
      * @return OBVRPFundsConfirmationResponse
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
@@ -51,7 +49,6 @@ public interface VrpClient {
      */
     OBVRPFundsConfirmationResponse getFundsConfirmation(String consentId,
                                                         OBVRPFundsConfirmationRequest obVRPFundsConfirmationRequest,
-                                                        AuthorizationContext authorizationContext,
                                                         AspspDetails aspspDetails);
 
     /**
@@ -80,7 +77,6 @@ public interface VrpClient {
      * Create a domestic VRP
      *
      * @param vrpRequest               The details of the domestic VRP to setup
-     * @param authorizationContext     The successful payment authorisation data
      * @param aspspDetails             The details of the ASPSP to send the request to
      * @param softwareStatementDetails The details of the software statement that the ASPSP registration uses
      * @return OBDomesticVRPResponse
@@ -90,7 +86,6 @@ public interface VrpClient {
      */
     OBDomesticVRPResponse submitDomesticVrp(
         OBDomesticVRPRequest vrpRequest,
-        AuthorizationContext authorizationContext,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails
     );

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -69,7 +69,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.transferwise.openbanking.client.test.factory.AccessTokenResponseFactory.aAccessTokenResponse;
-import static com.transferwise.openbanking.client.test.factory.AuthorizationContextFactory.aAuthorizationContext;
 import static com.transferwise.openbanking.client.test.factory.SoftwareStatementDetailsFactory.aSoftwareStatementDetails;
 
 @ExtendWith(MockitoExtension.class)
@@ -222,16 +221,14 @@ class RestVrpClientTest {
     void getFundsConfirmation() {
         String consentId = "vrp-consent-id";
         OBVRPFundsConfirmationRequest fundsConfirmationRequest = aVrpFundsConfirmationRequest();
-        AuthorizationContext authorizationContext = aAuthorizationContext();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito
             .when(oAuthClient.getAccessToken(
                 Mockito.argThat(request ->
-                    "authorization_code".equals(request.getRequestBody().get("grant_type")) &&
-                        authorizationContext.getAuthorizationCode().equals(request.getRequestBody().get("code")) &&
-                        authorizationContext.getRedirectUrl().equals(request.getRequestBody().get("redirect_uri"))),
+                    "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
+                        "payments".equals(request.getRequestBody().get("scope"))),
                 Mockito.eq(aspspDetails)))
             .thenReturn(accessTokenResponse);
 
@@ -248,7 +245,6 @@ class RestVrpClientTest {
         OBVRPFundsConfirmationResponse fundsConfirmationResponse = restVrpClient.getFundsConfirmation(
             consentId,
             fundsConfirmationRequest,
-            authorizationContext,
             aspspDetails);
 
         Assertions.assertEquals(mockFundsConfirmationResponse, fundsConfirmationResponse);
@@ -263,7 +259,6 @@ class RestVrpClientTest {
     void getFundsConfirmationThrowsApiCallExceptionOnApiCallFailure() {
         String consentId = "vrp-consent-id";
         OBVRPFundsConfirmationRequest fundsConfirmationRequest = aVrpFundsConfirmationRequest();
-        AuthorizationContext authorizationContext = aAuthorizationContext();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
@@ -278,7 +273,6 @@ class RestVrpClientTest {
             () -> restVrpClient.getFundsConfirmation(
                 consentId,
                 fundsConfirmationRequest,
-                authorizationContext,
                 aspspDetails
             ));
 
@@ -290,7 +284,6 @@ class RestVrpClientTest {
     void getFundsConfirmationThrowsApiCallExceptionPartialResponse(OBVRPFundsConfirmationResponse response) {
         String consentId = "vrp-consent-id";
         OBVRPFundsConfirmationRequest fundsConfirmationRequest = aVrpFundsConfirmationRequest();
-        AuthorizationContext authorizationContext = aAuthorizationContext();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
@@ -306,7 +299,6 @@ class RestVrpClientTest {
             () -> restVrpClient.getFundsConfirmation(
                 consentId,
                 fundsConfirmationRequest,
-                authorizationContext,
                 aspspDetails
             ));
 
@@ -468,15 +460,12 @@ class RestVrpClientTest {
         OBDomesticVRPRequest domesticVrpRequest = aDomesticVrpRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-        AuthorizationContext authorizationContext = aAuthorizationContext();
-
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito
             .when(oAuthClient.getAccessToken(
                 Mockito.argThat(request ->
-                    "authorization_code".equals(request.getRequestBody().get("grant_type")) &&
-                        authorizationContext.getAuthorizationCode().equals(request.getRequestBody().get("code")) &&
-                        authorizationContext.getRedirectUrl().equals(request.getRequestBody().get("redirect_uri"))),
+                    "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
+                        "payments".equals(request.getRequestBody().get("scope"))),
                 Mockito.eq(aspspDetails)))
             .thenReturn(accessTokenResponse);
 
@@ -505,7 +494,6 @@ class RestVrpClientTest {
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         OBDomesticVRPResponse domesticPaymentResponse = restVrpClient.submitDomesticVrp(domesticVrpRequest,
-            authorizationContext,
             aspspDetails,
             softwareStatementDetails);
 
@@ -519,7 +507,6 @@ class RestVrpClientTest {
         OBDomesticVRPRequest domesticVrpRequest = aDomesticVrpRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-        AuthorizationContext authorizationContext = aAuthorizationContext();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
@@ -535,7 +522,6 @@ class RestVrpClientTest {
         Assertions.assertThrows(ApiCallException.class,
             () -> restVrpClient.submitDomesticVrp(
                 domesticVrpRequest,
-                authorizationContext,
                 aspspDetails,
                 softwareStatementDetails));
 
@@ -549,7 +535,6 @@ class RestVrpClientTest {
         OBDomesticVRPRequest domesticVrpRequest = aDomesticVrpRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-        AuthorizationContext authorizationContext = aAuthorizationContext();
 
         AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
         Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
@@ -566,7 +551,6 @@ class RestVrpClientTest {
         Assertions.assertThrows(ApiCallException.class,
             () -> restVrpClient.submitDomesticVrp(
                 domesticVrpRequest,
-                authorizationContext,
                 aspspDetails,
                 softwareStatementDetails));
 

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -1,6 +1,5 @@
 package com.transferwise.openbanking.client.api.vrp;
 
-import com.transferwise.openbanking.client.api.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.common.IdempotencyKeyGenerator;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBActiveOrHistoricCurrencyAndAmount;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBCashAccountCreditor3;


### PR DESCRIPTION
## Context

Use client_credential grant type for initiating the vrp payment.  

## Changes

remove authentication context from vrp client payment initiation method. 
