### PR TITLE
Uk 2337 audience

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.2.2
+version=7.2.3

--- a/src/main/java/com/transferwise/openbanking/client/oauth/PrivateKeyJwtAuthentication.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/PrivateKeyJwtAuthentication.java
@@ -37,7 +37,7 @@ public class PrivateKeyJwtAuthentication implements ClientAuthentication {
         JwtClaims jwtClaims = new JwtClaims();
         jwtClaims.setIssuer(aspspDetails.getClientId());
         jwtClaims.setSubject(aspspDetails.getClientId());
-        jwtClaims.setAudience(aspspDetails.getPrivateKeyJwtAuthenticationAudience());
+        jwtClaims.setAudience(aspspDetails.getPrivateKeyJwtAuthenticationAudience() !=null ? aspspDetails.getPrivateKeyJwtAuthenticationAudience() : aspspDetails.getTokenUrl());
         jwtClaims.setIssuedAtToNow();
         jwtClaims.setExpirationTimeMinutesInTheFuture(CLAIMS_VALID_FOR_MINUTES);
         jwtClaims.setJwtId(UUID.randomUUID().toString());


### PR DESCRIPTION
## Context

currently the `AspsDetails.PrivateKeyJwtAuthenticationAudience` is defaulted in the interface as the TokenUrl, for the cop service we want to be able to override the `AspsDetails.PrivateKeyJwtAuthenticationAudience` to be a different value from the `TokenUrl` but we want to keep the same behaviour for those AspsDetails when the two matches without the need of explicitly configuring the PrivateKeyJwtAuthenticationAudience for all the existing AspsDetails records.

## Changes

- `PrivateKeyJwtAuthentication.getClientAssertionToken` now reproduces the logic that was present in the interface.
