### PR TITLE
Update BasePaymentClient to support exchange of code and refresh_token for access_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2022-03-25
+### Changed
+- Add `refresh_token` to `com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse` so it can be used to get valid access token
+- Add `BasePaymentClient.exchangeRefreshToken` method that can exchange refresh_token to access_token and refresh_token
+- Change method signature for `BasePaymentClient.exchangeAuthorizationCode` to return `AccessTokenResponse` and make it public
+
 ## [7.2.4] - 2022-02-22
 ### Changed
 - Handle no content response for PISP createDomesticPaymentConsent

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ OBWriteDomesticResponse5 paymentResponse = paymentClient.createDomesticPayment(p
     authorizationCode, 
     aspspDetails);
 ```
+## How to contribute
+
+1. Prepare a PR for review (all commits must be signed)
+2. We receive a notification and review your PR
+3. We merge approved PR and release a new version
+
+### How to configure GPG signing
+
+1. [Generate a GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key)
+2. [Upload your GPG public key to your GitHub account](https://docs.github.com/en/authentication/managing-commit-signature-verification/associating-an-email-with-your-gpg-key)
+3. [Configure Git to use your GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ ext {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 configurations {

--- a/build.publishing.gradle
+++ b/build.publishing.gradle
@@ -65,5 +65,6 @@ publishing {
 				password = System.env.MAVEN_PASSWORD as String
 			}
 		}
+        mavenLocal()
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=7.2.4
+version=8.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/common/BasePaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/common/BasePaymentClient.java
@@ -22,16 +22,22 @@ public class BasePaymentClient {
 
     private final OAuthClient oAuthClient;
 
-    protected String getClientCredentialsToken(AspspDetails aspspDetails) {
-        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest(PAYMENTS_SCOPE);
-        return getAccessToken(getAccessTokenRequest, aspspDetails);
-    }
-
-    protected String exchangeAuthorizationCode(AuthorizationContext authorizationContext, AspspDetails aspspDetails) {
+    public AccessTokenResponse exchangeAuthorizationCode(AuthorizationContext authorizationContext, AspspDetails aspspDetails) {
         GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.authorizationCodeRequest(
             authorizationContext.getAuthorizationCode(),
             authorizationContext.getRedirectUrl());
         return getAccessToken(getAccessTokenRequest, aspspDetails);
+    }
+
+    public AccessTokenResponse exchangeRefreshToken(String refreshToken, AspspDetails aspspDetails) {
+        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.refreshTokenRequest(
+            refreshToken);
+        return getAccessToken(getAccessTokenRequest, aspspDetails);
+    }
+
+    protected String getClientCredentialsToken(AspspDetails aspspDetails) {
+        GetAccessTokenRequest getAccessTokenRequest = GetAccessTokenRequest.clientCredentialsRequest(PAYMENTS_SCOPE);
+        return getAccessToken(getAccessTokenRequest, aspspDetails).getAccessToken();
     }
 
     protected String generateApiUrl(String url, String resource, AspspDetails aspspDetails) {
@@ -41,8 +47,7 @@ public class BasePaymentClient {
             resource);
     }
 
-    private String getAccessToken(GetAccessTokenRequest getAccessTokenRequest, AspspDetails aspspDetails) {
-        AccessTokenResponse accessTokenResponse = oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
-        return accessTokenResponse.getAccessToken();
+    private AccessTokenResponse getAccessToken(GetAccessTokenRequest getAccessTokenRequest, AspspDetails aspspDetails) {
+        return oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
@@ -89,7 +89,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                                                           SoftwareStatementDetails softwareStatementDetails) {
 
         OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getOrganisationId(),
-            exchangeAuthorizationCode(authorizationContext, aspspDetails),
+            exchangeAuthorizationCode(authorizationContext, aspspDetails).getAccessToken(),
             idempotencyKeyGenerator.generateKeyForSubmission(domesticPaymentRequest),
             jwtClaimsSigner.createDetachedSignature(domesticPaymentRequest, aspspDetails, softwareStatementDetails));
 
@@ -189,8 +189,9 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                                                                   AuthorizationContext authorizationContext,
                                                                   AspspDetails aspspDetails) {
 
-        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(aspspDetails.getOrganisationId(),
-            exchangeAuthorizationCode(authorizationContext, aspspDetails));
+        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(
+            aspspDetails.getOrganisationId(),
+            exchangeAuthorizationCode(authorizationContext, aspspDetails).getAccessToken());
 
         HttpEntity<?> request = new HttpEntity<>(headers);
 

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -194,11 +194,13 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
     @Override
     public OBDomesticVRPResponse submitDomesticVrp(
         OBDomesticVRPRequest vrpRequest,
+        String accessToken,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails
     ) {
-        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(aspspDetails.getOrganisationId(),
-            getClientCredentialsToken(aspspDetails),
+        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(
+            aspspDetails.getOrganisationId(),
+            accessToken,
             idempotencyKeyGenerator.generateKeyForSubmission(vrpRequest),
             jwtClaimsSigner.createDetachedSignature(vrpRequest, aspspDetails, softwareStatementDetails));
 

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
@@ -1,5 +1,6 @@
 package com.transferwise.openbanking.client.api.vrp;
 
+import com.transferwise.openbanking.client.api.common.AuthorizationContext;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentRequest;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPDetails;
@@ -9,6 +10,7 @@ import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPFundsCo
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPFundsConfirmationResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
+import com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse;
 
 /**
  * An interface specifying the operations for a client supporting version 3.1.9 domestic variable recurring payments.
@@ -29,6 +31,24 @@ public interface VrpClient {
     OBDomesticVRPConsentResponse createDomesticVrpConsent(OBDomesticVRPConsentRequest domesticVRPConsentRequest,
                                                           AspspDetails aspspDetails,
                                                           SoftwareStatementDetails softwareStatementDetails);
+
+    /**
+     * Exchange authorization code for access_token.
+     *
+     * @param authorizationContext Authorization context for a request
+     * @param aspspDetails The details of the ASPSP to send the request to
+     * @return AccessTokenResponse
+     */
+    AccessTokenResponse exchangeAuthorizationCode(AuthorizationContext authorizationContext, AspspDetails aspspDetails);
+
+    /**
+     * Exchange refresh token for access_token.
+     *
+     * @param refreshToken Refresh token
+     * @param aspspDetails The details of the ASPSP to send the request to
+     * @return AccessTokenResponse
+     */
+    AccessTokenResponse exchangeRefreshToken(String refreshToken, AspspDetails aspspDetails);
 
     /**
      * Get confirmation of whether not funds are available for a domestic VRP consent, which has been authorised
@@ -86,6 +106,7 @@ public interface VrpClient {
      */
     OBDomesticVRPResponse submitDomesticVrp(
         OBDomesticVRPRequest vrpRequest,
+        String accessToken,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails
     );

--- a/src/main/java/com/transferwise/openbanking/client/oauth/RestOAuthClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/RestOAuthClient.java
@@ -59,11 +59,9 @@ public class RestOAuthClient implements OAuthClient {
                 AccessTokenResponse.class);
             accessTokenResponse = response.getBody();
         } catch (RestClientResponseException e) {
-            log.error("Call to token endpoint failed, x-fapi-interaction-id [{}]", requestHeaders.getInteractionId(),  e);
             throw new ApiCallException("Call to token endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
                 e);
         } catch (RestClientException e) {
-            log.error("Call to token endpoint failed, x-fapi-interaction-id [{}]", requestHeaders.getInteractionId(),  e);
             throw new ApiCallException("Call to token endpoint failed, and no response body returned", e);
         }
 

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/AccessTokenResponse.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/AccessTokenResponse.java
@@ -15,6 +15,9 @@ public class AccessTokenResponse {
     @JsonProperty("access_token")
     private String accessToken;
 
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
     @JsonProperty("scope")
     private String scope;
 

--- a/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/domain/GetAccessTokenRequest.java
@@ -21,6 +21,7 @@ public class GetAccessTokenRequest {
     private static final String CLIENT_SECRET_PARAM = "client_secret";
     private static final String CLIENT_ASSERTION_TYPE_PARAM = "client_assertion_type";
     private static final String CLIENT_ASSERTION_PARAM = "client_assertion";
+    private static final String REFRESH_TOKEN_PARAM = "refresh_token";
 
     private final Map<String, String> requestBody = new HashMap<>();
     private final FapiHeaders requestHeaders = FapiHeaders.defaultHeaders();
@@ -46,6 +47,12 @@ public class GetAccessTokenRequest {
             .setRedirectUri(redirectUri);
     }
 
+    public static GetAccessTokenRequest refreshTokenRequest(String refreshToken) {
+        return new GetAccessTokenRequest()
+            .setGrantType(GrantType.REFRESH_TOKEN.getValue())
+            .setRefreshToken(refreshToken);
+    }
+
     public GetAccessTokenRequest setGrantType(String grantType) {
         setBodyParameter(GRANT_TYPE_PARAM, grantType);
         return this;
@@ -62,6 +69,11 @@ public class GetAccessTokenRequest {
 
     public GetAccessTokenRequest setAuthorisationCode(String authorisationCode) {
         setBodyParameter(CODE_PARAM, authorisationCode);
+        return this;
+    }
+
+    public GetAccessTokenRequest setRefreshToken(String authorisationCode) {
+        setBodyParameter(REFRESH_TOKEN_PARAM, authorisationCode);
         return this;
     }
 

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -459,15 +459,7 @@ class RestVrpClientTest {
         OBDomesticVRPRequest domesticVrpRequest = aDomesticVrpRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
-        AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
-        Mockito
-            .when(oAuthClient.getAccessToken(
-                Mockito.argThat(request ->
-                    "client_credentials".equals(request.getRequestBody().get("grant_type")) &&
-                        "payments".equals(request.getRequestBody().get("scope"))),
-                Mockito.eq(aspspDetails)))
-            .thenReturn(accessTokenResponse);
-
+        String accessToken = "access-token";
         Mockito.when(idempotencyKeyGenerator.generateKeyForSubmission(domesticVrpRequest))
             .thenReturn(IDEMPOTENCY_KEY);
 
@@ -482,7 +474,7 @@ class RestVrpClientTest {
         String jsonResponse = jsonConverter.writeValueAsString(mockDomesticPaymentResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(DOMESTIC_VRP_URL))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
-            .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
+            .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header("x-idempotency-key", IDEMPOTENCY_KEY))
@@ -492,7 +484,9 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.content().json(jsonConverter.writeValueAsString(domesticVrpRequest)))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        OBDomesticVRPResponse domesticPaymentResponse = restVrpClient.submitDomesticVrp(domesticVrpRequest,
+        OBDomesticVRPResponse domesticPaymentResponse = restVrpClient.submitDomesticVrp(
+            domesticVrpRequest,
+            accessToken,
             aspspDetails,
             softwareStatementDetails);
 
@@ -507,9 +501,7 @@ class RestVrpClientTest {
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
-        AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
-        Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
-            .thenReturn(accessTokenResponse);
+        String accessToken = "access-token";
 
         Mockito.when(idempotencyKeyGenerator.generateKeyForSubmission(Mockito.any(OBDomesticVRPRequest.class)))
             .thenReturn(IDEMPOTENCY_KEY);
@@ -521,6 +513,7 @@ class RestVrpClientTest {
         Assertions.assertThrows(ApiCallException.class,
             () -> restVrpClient.submitDomesticVrp(
                 domesticVrpRequest,
+                accessToken,
                 aspspDetails,
                 softwareStatementDetails));
 
@@ -535,10 +528,7 @@ class RestVrpClientTest {
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
 
-        AccessTokenResponse accessTokenResponse = aAccessTokenResponse();
-        Mockito.when(oAuthClient.getAccessToken(Mockito.any(), Mockito.any()))
-            .thenReturn(accessTokenResponse);
-
+        String accessToken = "access-token";
         Mockito.when(idempotencyKeyGenerator.generateKeyForSubmission(Mockito.any(OBDomesticVRPRequest.class)))
             .thenReturn(IDEMPOTENCY_KEY);
 
@@ -550,6 +540,7 @@ class RestVrpClientTest {
         Assertions.assertThrows(ApiCallException.class,
             () -> restVrpClient.submitDomesticVrp(
                 domesticVrpRequest,
+                accessToken,
                 aspspDetails,
                 softwareStatementDetails));
 


### PR DESCRIPTION
## Context
To implement VRP we need to have a possibility to exchange `code` to `access_token` and `refresh_token`. And also exchange `refresh_token` for valid `access_token`.  

## Changes
- Add `refresh_token` to `com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse` so it can be used to get valid access token
- Add `BasePaymentClient.exchangeRefreshToken` method that can exchange refresh_token to access_token and refresh_token
- Change method signature for `BasePaymentClient.exchangeAuthorizationCode` to return `AccessTokenResponse` and make it public

