### PR TITLE
Add default  method to support dynamic resource name for VRP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.1] - 2022-04-20
+## Changes
+- Add default `AspspDetails.getVrpBaseResourceName()` method to support dynamic resource name for VRP
+- Upgrade `com.diffplug.spotless` to `6.4.2`
+- Upgrade `io.swagger.codegen.v3:swagger-codegen-cli` to `3.0.34`
+- Upgrade `org.bitbucket.b_c:jose4j` to `0.7.11`
+- Upgrade `ch.qos.logback:logback-classic` to `1.2.11`
+
 ## [8.0.0] - 2022-03-25
 ### Changed
 - Add `refresh_token` to `com.transferwise.openbanking.client.oauth.domain.AccessTokenResponse` so it can be used to get valid access token

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'pmd'
     id 'com.github.spotbugs' version '5.0.6'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id "com.diffplug.spotless" version "6.3.0"
+    id "com.diffplug.spotless" version "6.4.2"
 }
 
 ext.projectName = "Openbanking client"
@@ -44,7 +44,7 @@ configurations {
 
 dependencies {
     openApiGen("org.openapitools:openapi-generator-cli:3.3.4")
-    swaggerCodegenV3("io.swagger.codegen.v3:swagger-codegen-cli:3.0.32")
+    swaggerCodegenV3("io.swagger.codegen.v3:swagger-codegen-cli:3.0.34")
     api("org.springframework:spring-web:${libs.spring}")
 
     implementation('org.apache.httpcomponents:httpclient:4.5.13')
@@ -54,7 +54,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${libs.jackson}")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${libs.jackson}")
 
-    api('org.bitbucket.b_c:jose4j:0.7.10')
+    api('org.bitbucket.b_c:jose4j:0.7.11')
 
     compileOnly("org.projectlombok:lombok:${libs.lombok}")
     testCompileOnly("org.projectlombok:lombok:${libs.lombok}")
@@ -74,7 +74,7 @@ dependencies {
 
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
 
-    testImplementation("ch.qos.logback:logback-classic:1.2.10")
+    testImplementation("ch.qos.logback:logback-classic:1.2.11")
 }
 
 swaggerSources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=8.0.0
+version=8.0.1

--- a/src/main/java/com/transferwise/openbanking/client/api/common/BasePaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/common/BasePaymentClient.java
@@ -47,6 +47,14 @@ public class BasePaymentClient {
             resource);
     }
 
+    protected String generateVrpApiUrl(String url, String resource, AspspDetails aspspDetails) {
+        return String.format(url,
+            aspspDetails.getApiBaseUrl("3", resource),
+            aspspDetails.getPaymentApiMinorVersion(),
+            aspspDetails.getVrpBaseResourceName(),
+            resource);
+    }
+
     private AccessTokenResponse getAccessToken(GetAccessTokenRequest getAccessTokenRequest, AspspDetails aspspDetails) {
         return oAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails);
     }

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestOperations;
 @Slf4j
 public class RestVrpClient extends BasePaymentClient implements VrpClient {
 
-    private static final String BASE_ENDPOINT_PATH_FORMAT = "%s/open-banking/v3.%s/vrp/%s";
+    private static final String BASE_ENDPOINT_PATH_FORMAT = "%s/open-banking/v3.%s/%s/%s";
 
     private static final String VRP_CONSENT_RESOURCE = "domestic-vrp-consents";
     private static final String CONSENT_BY_ID_ENDPOINT_PATH_FORMAT = BASE_ENDPOINT_PATH_FORMAT + "/{consentId}";
@@ -73,7 +73,8 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
 
         ResponseEntity<String> response;
         try {
-            response = restOperations.exchange(generateApiUrl(BASE_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
+            response = restOperations.exchange(
+                generateVrpApiUrl(BASE_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
                 HttpMethod.POST,
                 request,
                 String.class
@@ -110,7 +111,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         ResponseEntity<String> response;
         try {
             response = restOperations.exchange(
-                generateApiUrl(FUNDS_CONFIRMATION_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
+                generateVrpApiUrl(FUNDS_CONFIRMATION_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
                 HttpMethod.GET,
                 request,
                 String.class,
@@ -143,7 +144,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         ResponseEntity<String> response;
         try {
             response = restOperations.exchange(
-                generateApiUrl(CONSENT_BY_ID_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
+                generateVrpApiUrl(CONSENT_BY_ID_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
                 HttpMethod.GET,
                 request,
                 String.class,
@@ -176,7 +177,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         ResponseEntity<String> response;
         try {
             response = restOperations.exchange(
-                generateApiUrl(CONSENT_BY_ID_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
+                generateVrpApiUrl(CONSENT_BY_ID_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
                 HttpMethod.DELETE,
                 request,
                 String.class,
@@ -212,7 +213,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         ResponseEntity<String> response;
         try {
             response = restOperations.exchange(
-                generateApiUrl(BASE_ENDPOINT_PATH_FORMAT, VRP_RESOURCE, aspspDetails),
+                generateVrpApiUrl(BASE_ENDPOINT_PATH_FORMAT, VRP_RESOURCE, aspspDetails),
                 HttpMethod.POST,
                 request,
                 String.class);
@@ -242,7 +243,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         ResponseEntity<String> response;
         try {
             response = restOperations.exchange(
-                generateApiUrl(VRP_BY_ID_ENDPOINT_PATH_FORMAT, VRP_RESOURCE, aspspDetails),
+                generateVrpApiUrl(VRP_BY_ID_ENDPOINT_PATH_FORMAT, VRP_RESOURCE, aspspDetails),
                 HttpMethod.GET,
                 request,
                 String.class,
@@ -273,7 +274,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         ResponseEntity<String> response;
         try {
             response = restOperations.exchange(
-                generateApiUrl(VRP_DETAILS_BY_ID_ENDPOINT_PATH_FORMAT, VRP_RESOURCE, aspspDetails),
+                generateVrpApiUrl(VRP_DETAILS_BY_ID_ENDPOINT_PATH_FORMAT, VRP_RESOURCE, aspspDetails),
                 HttpMethod.GET,
                 request,
                 String.class,

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -261,4 +261,8 @@ public interface AspspDetails {
     default boolean registrationRequiresLowerCaseJtiClaim() {
         return false;
     }
+
+    default String getVrpBaseResourceName() {
+        return "pisp";
+    }
 }

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -76,8 +76,8 @@ class RestVrpClientTest {
 
     private static final String IDEMPOTENCY_KEY = "idempotency-key";
     private static final String DETACHED_JWS_SIGNATURE = "detached-jws-signature";
-    public static final String DOMESTIC_VRP_CONSENTS_URL = "https://aspsp.co.uk/open-banking/v3.1/vrp/domestic-vrp-consents";
-    public static final String DOMESTIC_VRP_URL = "https://aspsp.co.uk/open-banking/v3.1/vrp/domestic-vrps";
+    public static final String DOMESTIC_VRP_CONSENTS_URL = "https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-vrp-consents";
+    public static final String DOMESTIC_VRP_URL = "https://aspsp.co.uk/open-banking/v3.1/pisp/domestic-vrps";
 
     private static JsonConverter jsonConverter;
 


### PR DESCRIPTION
## Context
As mentioned in [OB Known Specification Issues v319_KI15](https://openbanking.atlassian.net/wiki/spaces/DZ/pages/47546479/Known+Specification+Issues) resource group of VRP endpoints will be changed from existing VRP resource group to PISP. But some banks still have VRP so adding a default method to `AspspDetails` that can be overrided.

## Changes
- Add default `AspspDetails.getVrpBaseResourceName()` method to support dynamic resource name for VRP
- Upgrade `com.diffplug.spotless` to `6.4.2`
- Upgrade `io.swagger.codegen.v3:swagger-codegen-cli` to `3.0.34`
- Upgrade `org.bitbucket.b_c:jose4j` to `0.7.11`
- Upgrade `ch.qos.logback:logback-classic` to `1.2.11`
