### PR TITLE
Update `specs/vrp-openapi.yaml` with VRP 3.1.9 specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.0] - 2022-05-04
+## Changes
+- Update `specs/vrp-openapi.yaml` with VRP 3.1.9 specification
+- Upgrade `com.diffplug.spotless` to `v6.5.1`
+- Upgrade `org.bitbucket.b_c:jose4j` to `0.7.12`
+
 ## [8.0.2] - 2022-04-20
 ## Changes
 - Add debug logs to `RestVrpClient` 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'pmd'
     id 'com.github.spotbugs' version '5.0.6'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id "com.diffplug.spotless" version "6.4.2"
+    id "com.diffplug.spotless" version "6.5.1"
 }
 
 ext.projectName = "Openbanking client"
@@ -54,7 +54,7 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${libs.jackson}")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${libs.jackson}")
 
-    api('org.bitbucket.b_c:jose4j:0.7.11')
+    api('org.bitbucket.b_c:jose4j:0.7.12')
 
     compileOnly("org.projectlombok:lombok:${libs.lombok}")
     testCompileOnly("org.projectlombok:lombok:${libs.lombok}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=8.0.2
+version=9.0.0

--- a/specs/vrp-openapi.yaml
+++ b/specs/vrp-openapi.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.0
 
 servers:
-  - url: "/open-banking/v3.1/vrp"
+  - url: "/open-banking/v3.1/pisp"
 
 info:
   title: OBIE VRP Profile
   description: VRP OpenAPI Specification
-  version: 3.1.8
+  version: 3.1.9
   termsOfService: "https://www.openbanking.org.uk/terms"
   contact:
     name: "Service Desk"
@@ -762,8 +762,6 @@ components:
                 - Authorised
                 - AwaitingAuthorisation
                 - Rejected
-                - Revoked
-                - Expired
             StatusUpdateDateTime:
               type: string
               format: date-time
@@ -774,8 +772,9 @@ components:
             Initiation:
               $ref: '#/components/schemas/OBDomesticVRPInitiation'
             DebtorAccount:
-              description: The value must be populated for GET responses once the consent is approved.
-              $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+              allOf:
+                - description: The value must be populated for GET responses once the consent is approved.
+                - $ref: '#/components/schemas/OBCashAccountDebtorWithName'
         Risk:
           $ref: '#/components/schemas/OBRisk1'
         Links:
@@ -815,7 +814,8 @@ components:
       required:
         - VRPType
         - PSUAuthenticationMethods
-
+        - MaximumIndividualAmount
+        - PeriodicLimits
       properties:
         ValidFromDateTime:
           type: string
@@ -831,6 +831,7 @@ components:
           $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
         PeriodicLimits:
           type: array
+          minItems: 1
           items:
             type: object
             required:
@@ -875,6 +876,12 @@ components:
           minItems: 1
           description: ^
             Indicates that the PSU authentication methods supported.
+        PSUInteractionTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/OBVRPInteractionTypes'
+          description: ^
+            Indicates interaction type, currently if customer is present or not present.
         SupplementaryData:
           type: object
           description: ^
@@ -886,10 +893,10 @@ components:
       properties:
         DebtorAccount:
           $ref: '#/components/schemas/OBCashAccountDebtorWithName'
-        CreditorAgent:
-          $ref: '#/components/schemas/OBBranchAndFinancialInstitutionIdentification6'
         CreditorAccount:
           $ref: '#/components/schemas/OBCashAccountCreditor3'
+        CreditorPostalAddress:
+          $ref: "#/components/schemas/OBPostalAddress6"
         RemittanceInformation:
           type: object
           description: ^
@@ -945,7 +952,9 @@ components:
         - Name
       properties:
         SchemeName:
-          $ref: '#/components/schemas/OBExternalAccountIdentification4Code'
+          allOf:
+            - $ref: '#/components/schemas/OBExternalAccountIdentification4Code'
+            - description: Name of the identification scheme, in a coded form as published in an external list.
 
         Identification:
           type: string
@@ -1002,7 +1011,6 @@ components:
             - PSUAuthenticationMethod
             - Initiation
             - Instruction
-            - Risk
           properties:
             ConsentId:
               type: string
@@ -1011,9 +1019,13 @@ components:
               description: |-
                 Identifier for the Domestic VRP Consent that this payment is made under.
             PSUAuthenticationMethod:
-              $ref: '#/components/schemas/OBVRPAuthenticationMethods'
-              description: >
-                The authentication method that was used to authenticate the PSU.
+              allOf:
+                - $ref: '#/components/schemas/OBVRPAuthenticationMethods'
+                - description: The authentication method that was used to authenticate the PSU.
+            PSUInteractionType:
+              allOf:
+                - $ref: '#/components/schemas/OBVRPInteractionTypes'
+                - description: The interaction style used.
             Initiation:
               $ref: '#/components/schemas/OBDomesticVRPInitiation'
             Instruction:
@@ -1067,6 +1079,14 @@ components:
                 - AcceptedSettlementInProcess
                 - Pending
                 - Rejected
+            StatusReason:
+              $ref: '#/components/schemas/OBVRPStatusReasonCode'
+            StatusReasonDescription:
+              type: string
+              minLength: 1
+              maxLength: 256
+              description: >
+                Description related to provided Status/StatusReason
             StatusUpdateDateTime:
               type: string
               format: date-time
@@ -1083,9 +1103,9 @@ components:
               description: >
                 Expected settlement date and time for the payment resource.
             Refund:
-              $ref: '#/components/schemas/OBCashAccountDebtorWithName'
-              description: >
-                Only included in the response if `Data.ReadRefundAccount` is set to `Yes` in the consent.
+              allOf:
+                - $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+                - description: Only included in the response if `Data.ReadRefundAccount` is set to `Yes` in the consent.
             Charges:
               type: array
               items:
@@ -1121,8 +1141,6 @@ components:
       properties:
         Data:
           type: object
-          required:
-            - PaymentTransactionId
           properties:
             PaymentStatus:
               type: array
@@ -1204,6 +1222,8 @@ components:
 
     OBVRPFundsConfirmationRequest:
       type: object
+      required:
+        - Data
       description: |-
         The OBVRPFundsConfirmationRequest object must be used to request funds availability for a specific amount in the Debtor Account included in the VRP consents.
       properties:
@@ -1211,7 +1231,6 @@ components:
           type: object
           required:
             - ConsentId
-            - Reference
             - InstructedAmount
           properties:
             ConsentId:
@@ -1231,6 +1250,8 @@ components:
 
     OBVRPFundsConfirmationResponse:
       type: object
+      required:
+        - Data
       description: |-
         The confirmation of funds response contains the result of a funds availability check.
       properties:
@@ -1240,7 +1261,6 @@ components:
             - FundsConfirmationId
             - ConsentId
             - CreationDateTime
-            - Reference
             - FundsAvailableResult
             - InstructedAmount
           properties:
@@ -1325,6 +1345,7 @@ components:
       required:
         - InstructionIdentification
         - EndToEndIdentification
+        - InstructedAmount
         - CreditorAccount
       properties:
         InstructionIdentification:
@@ -1351,8 +1372,8 @@ components:
           $ref: '#/components/schemas/OBExternalLocalInstrument1Code'
         InstructedAmount:
           $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
-        CreditorAgent:
-          $ref: '#/components/schemas/OBBranchAndFinancialInstitutionIdentification6'
+        CreditorPostalAddress:
+          $ref: "#/components/schemas/OBPostalAddress6"
         CreditorAccount:
           $ref: '#/components/schemas/OBCashAccountCreditor3'
         SupplementaryData:
@@ -1396,6 +1417,33 @@ components:
       type: string
       enum:
         - "UK.OBIE.BICFI"
+
+    OBExternalAccountType1Code:
+      description: "Specifies the type of account (personal or business)."
+      type: "string"
+      enum:
+        - "Business"
+        - "Personal"
+
+    OBExternalExtendedAccountType1Code:
+      description: "Specifies the extended type of account."
+      type: "string"
+      enum:
+        - Business
+        - BusinessSavingsAccount
+        - Charity
+        - Collection
+        - Corporate
+        - Ewallet
+        - Government
+        - Investment
+        - ISA
+        - JointPersonal
+        - Pension
+        - Personal
+        - PersonalSavingsAccount
+        - Premier
+        - Wealth
 
     OBExternalLocalInstrument1Code:
       type: string
@@ -1546,6 +1594,14 @@ components:
       description: Nation with its own government.
 
 
+    OBVRPStatusReasonCode:
+      type: string
+      enum:
+        - UK.OBIE.ExemptionNotApplied
+        - UK.OBIE.OtherReason
+      description: >
+        Reason Code provided for the status of a VRP. To be documented in the Developer Portal.
+
     OBVRPConsentType:
       type: string
       enum:
@@ -1558,13 +1614,35 @@ components:
         - UK.OBIE.SCA
         - UK.OBIE.SCANotRequired
 
+    OBVRPInteractionTypes:
+      type: string
+      enum:
+        - InSession
+        - OffSession
+
     OBRisk1:
       type: object
+      additionalProperties: false
       properties:
+        # OBExternalPaymentContext1Code
         PaymentContextCode:
           type: string
-          description: Specifies the payment context
+          description: |
+            Specifies the payment context
+            * BillPayment - @deprecated
+            * EcommerceGoods - @deprecated
+            * EcommerceServices - @deprecated
+            * Other - @deprecated
+            * PartyToParty - @deprecated
           enum:
+            - BillingGoodsAndServicesInAdvance
+            - BillingGoodsAndServicesInArrears
+            - PispPayee
+            - EcommerceMerchantInitiatedPayment
+            - FaceToFacePointOfSale
+            - TransferToSelf
+            - TransferToThirdParty
+            # Deprecated values
             - BillPayment
             - EcommerceGoods
             - EcommerceServices
@@ -1581,6 +1659,20 @@ components:
           minLength: 1
           maxLength: 70
           description: The unique customer identifier of the PSU with the merchant.
+        ContractPresentInidicator:
+          type: boolean
+          description: Indicates if Payee has a contractual relationship with the PISP.
+        BeneficiaryPrepopulatedIndicator:
+          type: boolean
+          description: Indicates if PISP has immutably prepopulated payment details in for the PSU.
+        PaymentPurposeCode:
+          type: string
+          minLength: 3
+          maxLength: 4
+          description: Category code, related to the type of services or goods that corresponds to the underlying purpose of the payment that conforms to Recommended UK Purpose Code in ISO 20022 Payment Messaging List
+        BeneficiaryAccountType:
+          $ref: '#/components/schemas/OBExternalExtendedAccountType1Code'
+        # PostalAddress2Lines
         DeliveryAddress:
           required:
             - Country


### PR DESCRIPTION
## Context
VRP 3.1.9 specification is [now live](https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/vrp-openapi.yaml) so we need to upgrade it 

## Changes
- Upgrade `com.diffplug.spotless` to `v6.5.1`
- Upgrade `org.bitbucket.b_c:jose4j` to `0.7.12`
