### PR TITLE
Update  so that debtorAccount field has OBCashAccountDebtorWithName type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.0] - 2022-05-05
+## Changes
+- Update `specs/vrp-opeapi.yaml` so that debtorAccount field has OBCashAccountDebtorWithName type
+  and ReadRefundAccount has "YES" and "NO" enum values
+
 ## [9.0.0] - 2022-05-04
 ## Changes
 - Update `specs/vrp-openapi.yaml` with VRP 3.1.9 specification

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=9.0.0
+version=10.0.0

--- a/specs/vrp-openapi.yaml
+++ b/specs/vrp-openapi.yaml
@@ -739,8 +739,8 @@ components:
             ReadRefundAccount:
               type: string
               enum:
-                - Yes
-                - No
+                - "Yes"
+                - "No"
               description: >
                 Indicates whether information about RefundAccount should be included in the payment response.
             ConsentId:
@@ -772,9 +772,8 @@ components:
             Initiation:
               $ref: '#/components/schemas/OBDomesticVRPInitiation'
             DebtorAccount:
-              allOf:
-                - description: The value must be populated for GET responses once the consent is approved.
-                - $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+                description: The value must be populated for GET responses once the consent is approved.
+                $ref: '#/components/schemas/OBCashAccountDebtorWithName'
         Risk:
           $ref: '#/components/schemas/OBRisk1'
         Links:
@@ -798,8 +797,8 @@ components:
             ReadRefundAccount:
               type: string
               enum:
-                - Yes
-                - No
+                - "Yes"
+                - "No"
               description: >
                 Indicates whether information about RefundAccount should be included in the payment response.
             ControlParameters:
@@ -929,20 +928,17 @@ components:
           type: string
           minLength: 1
           maxLength: 256
-          description: ^
-            Identification assigned by an institution to identify an account. This identification is known by the account owner.
+          description: Identification assigned by an institution to identify an account. This identification is known by the account owner.
         Name:
           type: string
           minLength: 1
           maxLength: 350
-          description: ^
-            Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
+          description: Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
         SecondaryIdentification:
           type: string
           minLength: 1
           maxLength: 34
-          description: ^
-            This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)
+          description: This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)
 
     OBCashAccountCreditor3:
       type: object
@@ -955,7 +951,6 @@ components:
           allOf:
             - $ref: '#/components/schemas/OBExternalAccountIdentification4Code'
             - description: Name of the identification scheme, in a coded form as published in an external list.
-
         Identification:
           type: string
           minLength: 1

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -723,7 +723,7 @@ class RestVrpClientTest {
             .creditorAccount(creditorAccount)
             .remittanceInformation(remittanceInformation);
         OBDomesticVRPConsentRequestData data = new OBDomesticVRPConsentRequestData()
-            .readRefundAccount(OBDomesticVRPConsentRequestData.ReadRefundAccountEnum.TRUE)
+            .readRefundAccount(OBDomesticVRPConsentRequestData.ReadRefundAccountEnum.YES)
             .controlParameters(controlParameters)
             .initiation(initiation);
         OBRisk1 risk = new OBRisk1()


### PR DESCRIPTION
## Context
`OBDomesticVRPConsentResponseData.debtorAccount` has type `Object` where it should be `OBCashAccountDebtorWithName`.
As Yes and No are reserved in openapi they automatically transforms to True and False. Adding quotes.

## Changes
- Update `specs/vrp-opeapi.yaml` so that debtorAccount field has OBCashAccountDebtorWithName type
  and ReadRefundAccount has "YES" and "NO" enum values