### PR TITLE
Extend existing ApiCallException class with two implementations: PaymentApiCallException and VrpApiCallException [UKGRO-235]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.0.0] - 2022-07-05
+## Changes
+- Extend existing `ApiCallException` class with two implementations: `PaymentApiCallException` and `VrpApiCallException`.
+  New error classes may contain additional information about an error such as response code, Open Banking response error 
+  code and a bank error description.
+- Upgrade `com.diffplug.spotless` to `v6.8.0`
+- Upgrade `com.github.spotbugs` to `v5.0.9`
+
 ## [10.0.0] - 2022-05-05
 ## Changes
 - Update `specs/vrp-opeapi.yaml` so that debtorAccount field has OBCashAccountDebtorWithName type

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id 'java-library'
     id 'checkstyle'
     id 'pmd'
-    id 'com.github.spotbugs' version '5.0.6'
+    id 'com.github.spotbugs' version '5.0.9'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id "com.diffplug.spotless" version "6.5.1"
+    id "com.diffplug.spotless" version "6.8.0"
 }
 
 ext.projectName = "Openbanking client"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=10.0.0
+version=11.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentApiCallException.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentApiCallException.java
@@ -1,0 +1,31 @@
+package com.transferwise.openbanking.client.api.payment.v3;
+
+import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBErrorResponse1;
+import com.transferwise.openbanking.client.error.ApiCallException;
+import lombok.Getter;
+
+/**
+ * Indicates that a HTTP call to an ASPSP failed, the request could not be successfully sent or the ASPSP did not
+ * respond in the expected way.
+ */
+@Getter
+public class PaymentApiCallException extends ApiCallException {
+
+    /**
+     * Open Banking error response.
+     */
+    private final OBErrorResponse1 errorResponse;
+
+    public PaymentApiCallException(String message) {
+        this(message, null, null);
+    }
+
+    public PaymentApiCallException(String message, Throwable cause) {
+        this(message, cause, null);
+    }
+
+    public PaymentApiCallException(String message, Throwable cause, OBErrorResponse1 errorResponse) {
+        super(message, cause);
+        this.errorResponse = errorResponse;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/PaymentClient.java
@@ -34,7 +34,7 @@ public interface PaymentClient {
      * <p>
      * This involves exchanging the provided authorization code for an access token, if the authorization code has
      * already been exchanged, further attempts to exchange it will be rejected by the ASPSP and a
-     * {@link com.transferwise.openbanking.client.error.ApiCallException} will be thrown. If the implementation caches
+     * {@link com.transferwise.openbanking.client.api.payment.v3.PaymentApiCallException} will be thrown. If the implementation caches
      * or otherwise stores access tokens, then the issue is avoided.
      *
      * @param domesticPaymentRequest   The details of the payment to submit for execution
@@ -81,7 +81,7 @@ public interface PaymentClient {
      * <p>
      * This involves exchanging the provided authorization code for an access token, if the authorization code has
      * already been exchanged, further attempts to exchange it will be rejected by the ASPSP and a
-     * {@link com.transferwise.openbanking.client.error.ApiCallException} will be thrown. If the implementation caches
+     * {@link com.transferwise.openbanking.client.api.payment.v3.PaymentApiCallException} will be thrown. If the implementation caches
      * or otherwise stores access tokens, then the issue is avoided.
      *
      * @param consentId            The ID of the domestic payment consent to get the funds confirmation for

--- a/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClient.java
@@ -9,9 +9,9 @@ import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBWriteD
 import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBWriteDomesticConsentResponse5;
 import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBWriteDomesticResponse5;
 import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBWriteFundsConfirmationResponse1;
+import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBErrorResponse1;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
-import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -69,10 +69,12 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                 request,
                 String.class);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to create payment consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new PaymentApiCallException("Call to create payment consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to create payment consent endpoint failed, and no response body returned", e);
+            throw new PaymentApiCallException("Call to create payment consent endpoint failed, and no response body returned", e);
         }
 
         OBWriteDomesticConsentResponse5 domesticPaymentConsentResponse = response.getBody() != null ? jsonConverter.readValue(response.getBody(),
@@ -107,10 +109,12 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                 request,
                 String.class);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to submit payment endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new PaymentApiCallException("Call to submit payment endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to submit payment endpoint failed, and no response body returned", e);
+            throw new PaymentApiCallException("Call to submit payment endpoint failed, and no response body returned", e);
         }
 
         OBWriteDomesticResponse5 domesticPaymentResponse = jsonConverter.readValue(response.getBody(),
@@ -139,10 +143,12 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                 String.class,
                 consentId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get payment consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new PaymentApiCallException("Call to get payment consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get payment consent endpoint failed, and no response body returned", e);
+            throw new PaymentApiCallException("Call to get payment consent endpoint failed, and no response body returned", e);
         }
 
         OBWriteDomesticConsentResponse5 domesticPaymentConsentResponse = jsonConverter.readValue(response.getBody(),
@@ -171,10 +177,12 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                 String.class,
                 domesticPaymentId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get payment endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new PaymentApiCallException("Call to get payment endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get payment endpoint failed, and no response body returned", e);
+            throw new PaymentApiCallException("Call to get payment endpoint failed, and no response body returned", e);
         }
 
         OBWriteDomesticResponse5 domesticPaymentResponse = jsonConverter.readValue(response.getBody(),
@@ -206,10 +214,12 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
                 String.class,
                 consentId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get confirmation of funds endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new PaymentApiCallException("Call to get confirmation of funds endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get confirmation of funds endpoint failed, and no response body returned",
+            throw new PaymentApiCallException("Call to get confirmation of funds endpoint failed, and no response body returned",
                 e);
         }
 
@@ -226,7 +236,7 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
             response.getData().getStatus() == null ||
             response.getData().getConsentId() == null ||
             response.getData().getConsentId().isBlank()) {
-            throw new ApiCallException("Empty or partial domestic payment consent response returned " + response);
+            throw new PaymentApiCallException("Empty or partial domestic payment consent response returned " + response);
         }
     }
 
@@ -236,13 +246,21 @@ public class RestPaymentClient extends BasePaymentClient implements PaymentClien
             response.getData().getStatus() == null ||
             response.getData().getDomesticPaymentId() == null ||
             response.getData().getDomesticPaymentId().isBlank()) {
-            throw new ApiCallException("Empty or partial domestic payment response returned " + response);
+            throw new PaymentApiCallException("Empty or partial domestic payment response returned " + response);
         }
     }
 
     private void validateResponse(OBWriteFundsConfirmationResponse1 response) {
         if (response == null || response.getData() == null) {
-            throw new ApiCallException("Empty or partial funds confirmation response returned " + response);
+            throw new PaymentApiCallException("Empty or partial funds confirmation response returned " + response);
+        }
+    }
+
+    private OBErrorResponse1 mapBodyToObErrorResponse(String responseBodyAsString) {
+        try {
+            return jsonConverter.readValue(responseBodyAsString, OBErrorResponse1.class);
+        } catch (Exception ex) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -8,11 +8,11 @@ import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVR
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPDetails;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPRequest;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPResponse;
+import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBErrorResponse1;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPFundsConfirmationRequest;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPFundsConfirmationResponse;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
-import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
@@ -81,9 +81,10 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 String.class
             );
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to create VRP consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'", e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to create VRP consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'", e, errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to create VRP consent endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to create VRP consent endpoint failed, and no response body returned", e);
         }
         log.debug("method=createDomesticVrpConsentResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
         OBDomesticVRPConsentResponse domesticVRPConsentResponse = jsonConverter.readValue(response.getBody(),
@@ -120,9 +121,10 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 consentId
             );
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get VRP confirmation of funds endpoint failed, body returned '" + e.getResponseBodyAsString() + "'", e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to get VRP confirmation of funds endpoint failed, body returned '" + e.getResponseBodyAsString() + "'", e, errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get VRP confirmation of funds endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to get VRP confirmation of funds endpoint failed, and no response body returned", e);
         }
 
         log.debug("method=getFundsConfirmationResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
@@ -154,10 +156,12 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 String.class,
                 consentId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get VRP consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to get VRP consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get VRP consent endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to get VRP consent endpoint failed, and no response body returned", e);
         }
 
         log.debug("method=getDomesticVrpConsentResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
@@ -189,10 +193,12 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 String.class,
                 consentId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to delete VRP consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to delete VRP consent endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to delete VRP consent endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to delete VRP consent endpoint failed, and no response body returned", e);
         }
 
         log.debug("method=deleteDomesticVrpConsentResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
@@ -226,10 +232,12 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 request,
                 String.class);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to submit VRP endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to submit VRP endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to submit VRP endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to submit VRP endpoint failed, and no response body returned", e);
         }
 
         log.debug("method=submitDomesticVrpResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
@@ -259,10 +267,12 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 String.class,
                 domesticVrpId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get VRP endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to get VRP endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get VRP endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to get VRP endpoint failed, and no response body returned", e);
         }
 
         log.debug("method=getDomesticVrpResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
@@ -292,10 +302,12 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
                 String.class,
                 domesticVrpId);
         } catch (RestClientResponseException e) {
-            throw new ApiCallException("Call to get VRP endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
-                e);
+            OBErrorResponse1 errorResponse = mapBodyToObErrorResponse(e.getResponseBodyAsString());
+            throw new VrpApiCallException("Call to get VRP endpoint failed, body returned '" + e.getResponseBodyAsString() + "'",
+                e,
+                errorResponse);
         } catch (RestClientException e) {
-            throw new ApiCallException("Call to get VRP endpoint failed, and no response body returned", e);
+            throw new VrpApiCallException("Call to get VRP endpoint failed, and no response body returned", e);
         }
 
         log.debug("method=getDomesticVrpDetailsResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(), response.getHeaders());
@@ -311,14 +323,15 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             response.getData() == null ||
             response.getData().getStatus() == null ||
             response.getData().getConsentId() == null ||
-            response.getData().getConsentId().isBlank()) {
-            throw new ApiCallException("Empty or partial VRP consent response returned " + response);
+            response.getData().getConsentId().isBlank()
+        ) {
+            throw new VrpApiCallException("Empty or partial VRP consent response returned ");
         }
     }
 
     private void validateResponse(OBVRPFundsConfirmationResponse response) {
         if (response == null || response.getData() == null) {
-            throw new ApiCallException("Empty or partial VRP funds confirmation response returned " + response);
+            throw new VrpApiCallException("Empty or partial VRP funds confirmation response returned ");
         }
     }
 
@@ -327,10 +340,10 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             return;
         }
         if (response.getStatusCode().is4xxClientError() || response.getStatusCode().is5xxServerError()) {
-            throw new ApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().name());
+            throw new VrpApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().name());
         }
         log.info("Call to delete VRP consent endpoint failed with unexpected status code {}", response.getStatusCode().value());
-        throw new ApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().name());
+        throw new VrpApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().name());
     }
 
 
@@ -342,7 +355,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             response.getData().getConsentId().isBlank() ||
             response.getData().getDomesticVRPId() == null ||
             response.getData().getDomesticVRPId().isBlank()) {
-            throw new ApiCallException("Empty or partial domestic VRP response returned " + response);
+            throw new VrpApiCallException("Empty or partial domestic VRP response returned ");
         }
     }
 
@@ -351,7 +364,15 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             response.getData() == null ||
             response.getData().getPaymentStatus() == null ||
             response.getData().getPaymentStatus().isEmpty()) {
-            throw new ApiCallException("Empty or partial domestic VRP details response returned " + response);
+            throw new VrpApiCallException("Empty or partial domestic VRP details response returned " + response);
+        }
+    }
+
+    private OBErrorResponse1 mapBodyToObErrorResponse(String responseBodyAsString) {
+        try {
+            return jsonConverter.readValue(responseBodyAsString, OBErrorResponse1.class);
+        } catch (Exception ex) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpApiCallException.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpApiCallException.java
@@ -1,0 +1,31 @@
+package com.transferwise.openbanking.client.api.vrp;
+
+import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBErrorResponse1;
+import com.transferwise.openbanking.client.error.ApiCallException;
+import lombok.Getter;
+
+/**
+ * Indicates that a HTTP call to an ASPSP failed, the request could not be successfully sent or the ASPSP did not
+ * respond in the expected way.
+ */
+@Getter
+public class VrpApiCallException extends ApiCallException {
+
+    /**
+     * Open Banking error response.
+     */
+    private final OBErrorResponse1 errorResponse;
+
+    public VrpApiCallException(String message) {
+        this(message, null, null);
+    }
+
+    public VrpApiCallException(String message, Throwable cause) {
+        this(message, cause, null);
+    }
+
+    public VrpApiCallException(String message, Throwable cause, OBErrorResponse1 errorResponse) {
+        super(message, cause);
+        this.errorResponse = errorResponse;
+    }
+}

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
@@ -36,7 +36,7 @@ public interface VrpClient {
      * Exchange authorization code for access_token.
      *
      * @param authorizationContext Authorization context for a request
-     * @param aspspDetails The details of the ASPSP to send the request to
+     * @param aspspDetails         The details of the ASPSP to send the request to
      * @return AccessTokenResponse
      */
     AccessTokenResponse exchangeAuthorizationCode(AuthorizationContext authorizationContext, AspspDetails aspspDetails);
@@ -56,7 +56,7 @@ public interface VrpClient {
      * <p>
      * This involves exchanging the provided authorization code for an access token, if the authorization code has
      * already been exchanged, further attempts to exchange it will be rejected by the ASPSP and a
-     * {@link com.transferwise.openbanking.client.error.ApiCallException} will be thrown. If the implementation caches
+     * {@link com.transferwise.openbanking.client.api.vrp.VrpApiCallException} will be thrown. If the implementation caches
      * or otherwise stores access tokens, then the issue is avoided.
      *
      * @param consentId                     The ID of the domestic VRP consent to get the details of
@@ -86,7 +86,8 @@ public interface VrpClient {
     /**
      * Delete a domestic VRP
      *
-     * @param consentId ConsentId
+     * @param consentId    ConsentId
+     * @param aspspDetails The details of the ASPSP to send the request to
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
      *                                                                   failed
@@ -97,6 +98,7 @@ public interface VrpClient {
      * Create a domestic VRP
      *
      * @param vrpRequest               The details of the domestic VRP to setup
+     * @param accessToken              The access token
      * @param aspspDetails             The details of the ASPSP to send the request to
      * @param softwareStatementDetails The details of the software statement that the ASPSP registration uses
      * @return OBDomesticVRPResponse

--- a/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/payment/v3/RestPaymentClientTest.java
@@ -22,7 +22,6 @@ import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBWriteF
 import com.transferwise.openbanking.client.api.payment.v3.model.payment.OBWriteFundsConfirmationResponse1DataFundsAvailableResult;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
-import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.json.JacksonJsonConverter;
 import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
@@ -147,7 +146,7 @@ class RestPaymentClientTest {
     }
 
     @Test
-    void createDomesticPaymentConsentThrowsApiCallExceptionOnApiCallFailure() {
+    void createDomesticPaymentConsentThrowsPaymentApiCallExceptionOnApiCallFailure() {
         OBWriteDomesticConsent4 domesticPaymentConsentRequest = aDomesticPaymentConsentRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
@@ -163,7 +162,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.createDomesticPaymentConsent(
                 domesticPaymentConsentRequest,
                 aspspDetails,
@@ -173,7 +172,7 @@ class RestPaymentClientTest {
     }
 
     @Test
-    void createDomesticPaymentConsentThrowsApiCallExceptionOnResponseWithNoContent() {
+    void createDomesticPaymentConsentThrowsPaymentApiCallExceptionOnResponseWithNoContent() {
         OBWriteDomesticConsent4 domesticPaymentConsentRequest = aDomesticPaymentConsentRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
@@ -189,7 +188,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withNoContent());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.createDomesticPaymentConsent(
                 domesticPaymentConsentRequest,
                 aspspDetails,
@@ -200,7 +199,7 @@ class RestPaymentClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialDomesticPaymentConsentResponses.class)
-    void createDomesticPaymentConsentThrowsApiCallExceptionOnPartialResponse(OBWriteDomesticConsentResponse5 response)
+    void createDomesticPaymentConsentThrowsPaymentApiCallExceptionOnPartialResponse(OBWriteDomesticConsentResponse5 response)
         throws Exception {
 
         OBWriteDomesticConsent4 domesticPaymentConsentRequest = aDomesticPaymentConsentRequest();
@@ -219,7 +218,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.createDomesticPaymentConsent(
                 domesticPaymentConsentRequest,
                 aspspDetails,
@@ -280,7 +279,7 @@ class RestPaymentClientTest {
     }
 
     @Test
-    void submitDomesticPaymentThrowsApiCallExceptionOnApiCallFailure() {
+    void submitDomesticPaymentThrowsPaymentApiCallExceptionOnApiCallFailure() {
         OBWriteDomestic2 domesticPaymentRequest = aDomesticPaymentRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
@@ -297,7 +296,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withBadRequest());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.submitDomesticPayment(
                 domesticPaymentRequest,
                 authorizationContext,
@@ -309,7 +308,7 @@ class RestPaymentClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialDomesticPaymentResponses.class)
-    void submitDomesticPaymentThrowsApiCallExceptionOnPartialResponse(OBWriteDomesticResponse5 response)
+    void submitDomesticPaymentThrowsPaymentApiCallExceptionOnPartialResponse(OBWriteDomesticResponse5 response)
         throws Exception {
 
         OBWriteDomestic2 domesticPaymentRequest = aDomesticPaymentRequest();
@@ -329,7 +328,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.submitDomesticPayment(
                 domesticPaymentRequest,
                 authorizationContext,
@@ -376,7 +375,7 @@ class RestPaymentClientTest {
     }
 
     @Test
-    void getDomesticPaymentConsentThrowsApiCallExceptionOnApiCallFailure() {
+    void getDomesticPaymentConsentThrowsPaymentApiCallExceptionOnApiCallFailure() {
         String consentId = "consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -388,7 +387,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.getDomesticPaymentConsent(consentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -396,7 +395,7 @@ class RestPaymentClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialDomesticPaymentConsentResponses.class)
-    void getDomesticPaymentConsentThrowsApiCallExceptionPartialResponse(OBWriteDomesticConsentResponse5 response)
+    void getDomesticPaymentConsentThrowsPaymentApiCallExceptionPartialResponse(OBWriteDomesticConsentResponse5 response)
         throws Exception {
         String consentId = "consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
@@ -410,7 +409,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.getDomesticPaymentConsent(consentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -452,7 +451,7 @@ class RestPaymentClientTest {
     }
 
     @Test
-    void getDomesticPaymentThrowsApiCallExceptionOnApiCallFailure() {
+    void getDomesticPaymentThrowsPaymentApiCallExceptionOnApiCallFailure() {
         String domesticPaymentId = "domestic-payment-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -464,7 +463,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.getDomesticPayment(domesticPaymentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -472,7 +471,7 @@ class RestPaymentClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialDomesticPaymentResponses.class)
-    void getDomesticPaymentThrowsApiCallExceptionPartialResponse(OBWriteDomesticResponse5 response) throws Exception {
+    void getDomesticPaymentThrowsPaymentApiCallExceptionPartialResponse(OBWriteDomesticResponse5 response) throws Exception {
         String domesticPaymentId = "domestic-payment-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -485,7 +484,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.getDomesticPayment(domesticPaymentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -530,7 +529,7 @@ class RestPaymentClientTest {
     }
 
     @Test
-    void getFundsConfirmationThrowsApiCallExceptionOnApiCallFailure() {
+    void getFundsConfirmationThrowsPaymentApiCallExceptionOnApiCallFailure() {
         String consentId = "consent-id";
         AuthorizationContext authorizationContext = aAuthorizationContext();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
@@ -543,7 +542,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.getFundsConfirmation(consentId, authorizationContext, aspspDetails));
 
         mockAspspServer.verify();
@@ -551,7 +550,7 @@ class RestPaymentClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialFundsConfirmationResponses.class)
-    void getFundsConfirmationThrowsApiCallExceptionPartialResponse(OBWriteFundsConfirmationResponse1 response)
+    void getFundsConfirmationThrowsPaymentApiCallExceptionPartialResponse(OBWriteFundsConfirmationResponse1 response)
         throws Exception {
         String consentId = "consent-id";
         AuthorizationContext authorizationContext = aAuthorizationContext();
@@ -566,7 +565,7 @@ class RestPaymentClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(PaymentApiCallException.class,
             () -> restPaymentClient.getFundsConfirmation(consentId, authorizationContext, aspspDetails));
 
         mockAspspServer.verify();

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -33,7 +33,6 @@ import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPFundsCo
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPRemittanceInformation;
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
-import com.transferwise.openbanking.client.error.ApiCallException;
 import com.transferwise.openbanking.client.json.JacksonJsonConverter;
 import com.transferwise.openbanking.client.json.JsonConverter;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
@@ -162,7 +161,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void createDomesticVrpConsentThrowsApiCallExceptionOnApiCallFailure() {
+    void createDomesticVrpConsentThrowsVrpApiCallExceptionOnApiCallFailure() {
         OBDomesticVRPConsentRequest domesticVRPConsentRequest = aDomesticVrpConsentRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
@@ -178,7 +177,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.createDomesticVrpConsent(
                 domesticVRPConsentRequest,
                 aspspDetails,
@@ -190,7 +189,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialDomesticVrpConsentResponses.class)
-    void createDomesticVrpConsentThrowsApiCallExceptionOnPartialResponse(OBDomesticVRPConsentResponse response) {
+    void createDomesticVrpConsentThrowsVrpApiCallExceptionOnPartialResponse(OBDomesticVRPConsentResponse response) {
         OBDomesticVRPConsentRequest domesticVRPConsentRequest = aDomesticVrpConsentRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
@@ -207,7 +206,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.createDomesticVrpConsent(
                 domesticVRPConsentRequest,
                 aspspDetails,
@@ -255,7 +254,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void getFundsConfirmationThrowsApiCallExceptionOnApiCallFailure() {
+    void getFundsConfirmationThrowsVrpApiCallExceptionOnApiCallFailure() {
         String consentId = "vrp-consent-id";
         OBVRPFundsConfirmationRequest fundsConfirmationRequest = aVrpFundsConfirmationRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
@@ -268,7 +267,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getFundsConfirmation(
                 consentId,
                 fundsConfirmationRequest,
@@ -280,7 +279,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialVrpFundsConfirmationResponses.class)
-    void getFundsConfirmationThrowsApiCallExceptionPartialResponse(OBVRPFundsConfirmationResponse response) {
+    void getFundsConfirmationThrowsVrpApiCallExceptionPartialResponse(OBVRPFundsConfirmationResponse response) {
         String consentId = "vrp-consent-id";
         OBVRPFundsConfirmationRequest fundsConfirmationRequest = aVrpFundsConfirmationRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
@@ -294,7 +293,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getFundsConfirmation(
                 consentId,
                 fundsConfirmationRequest,
@@ -341,7 +340,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void getDomesticVrpConsentThrowsApiCallExceptionOnApiCallFailure() {
+    void getDomesticVrpConsentThrowsVrpApiCallExceptionOnApiCallFailure() {
         String consentId = "vrp-consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -353,7 +352,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getDomesticVrpConsent(consentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -361,7 +360,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(PartialDomesticVrpConsentResponses.class)
-    void getDomesticVrpConsentThrowsApiCallExceptionPartialResponse(OBDomesticVRPConsentResponse response) {
+    void getDomesticVrpConsentThrowsVrpApiCallExceptionPartialResponse(OBDomesticVRPConsentResponse response) {
         String consentId = "vrp-consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -374,7 +373,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getDomesticVrpConsent(consentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -416,7 +415,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void deleteDomesticVrpConsentThrowsApiCallExceptionOnApiCallFailure() {
+    void deleteDomesticVrpConsentThrowsVrpApiCallExceptionOnApiCallFailure() {
         String consentId = "vrp-consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -428,7 +427,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.DELETE))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.deleteDomesticVrpConsent(consentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -436,7 +435,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(DeleteVrpConsentResponses.class)
-    void deleteDomesticVrpConsentThrowsApiCallExceptionPartialResponse(DefaultResponseCreator response) {
+    void deleteDomesticVrpConsentThrowsVrpApiCallExceptionPartialResponse(DefaultResponseCreator response) {
         String consentId = "vrp-consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -448,7 +447,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.DELETE))
             .andRespond(response);
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.deleteDomesticVrpConsent(consentId, aspspDetails));
 
         mockAspspServer.verify();
@@ -496,7 +495,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void submitDomesticVrpThrowsApiCallExceptionOnApiCallFailure() {
+    void submitDomesticVrpThrowsVrpApiCallExceptionOnApiCallFailure() {
         OBDomesticVRPRequest domesticVrpRequest = aDomesticVrpRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
         SoftwareStatementDetails softwareStatementDetails = aSoftwareStatementDetails();
@@ -510,7 +509,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withBadRequest());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.submitDomesticVrp(
                 domesticVrpRequest,
                 accessToken,
@@ -522,7 +521,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(RestVrpClientTest.PartialDomesticVrpResponses.class)
-    void submitDomesticVrpThrowsApiCallExceptionOnPartialResponse(OBDomesticVRPResponse response) {
+    void submitDomesticVrpThrowsVrpApiCallExceptionOnPartialResponse(OBDomesticVRPResponse response) {
 
         OBDomesticVRPRequest domesticVrpRequest = aDomesticVrpRequest();
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
@@ -537,7 +536,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.submitDomesticVrp(
                 domesticVrpRequest,
                 accessToken,
@@ -582,7 +581,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void getDomesticVrpThrowsApiCallExceptionOnApiCallFailure() {
+    void getDomesticVrpThrowsVrpApiCallExceptionOnApiCallFailure() {
         String vrpId = "vrp-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -594,7 +593,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getDomesticVrp(vrpId, aspspDetails));
 
         mockAspspServer.verify();
@@ -602,7 +601,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(RestVrpClientTest.PartialDomesticVrpResponses.class)
-    void getDomesticVrpThrowsApiCallExceptionPartialResponse(OBDomesticVRPResponse response) {
+    void getDomesticVrpThrowsVrpApiCallExceptionPartialResponse(OBDomesticVRPResponse response) {
         String vrpId = "vrp-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -615,7 +614,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getDomesticVrp(vrpId, aspspDetails));
 
         mockAspspServer.verify();
@@ -656,7 +655,7 @@ class RestVrpClientTest {
     }
 
     @Test
-    void getDomesticVrpDetailsThrowsApiCallExceptionOnApiCallFailure() {
+    void getDomesticVrpDetailsThrowsVrpApiCallExceptionOnApiCallFailure() {
         String vrpId = "vrp-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -668,7 +667,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withServerError());
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getDomesticVrpDetails(vrpId, aspspDetails));
 
         mockAspspServer.verify();
@@ -676,7 +675,7 @@ class RestVrpClientTest {
 
     @ParameterizedTest
     @ArgumentsSource(RestVrpClientTest.PartialDomesticVrpDetailsResponses.class)
-    void getDomesticVrpDetailsThrowsApiCallExceptionPartialResponse(OBDomesticVRPDetails response) {
+    void getDomesticVrpDetailsThrowsVrpApiCallExceptionPartialResponse(OBDomesticVRPDetails response) {
         String vrpId = "vrp-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -689,7 +688,7 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        Assertions.assertThrows(ApiCallException.class,
+        Assertions.assertThrows(VrpApiCallException.class,
             () -> restVrpClient.getDomesticVrpDetails(vrpId, aspspDetails));
 
         mockAspspServer.verify();


### PR DESCRIPTION
## Context
The problem is openbanking-client returning ApiCallException with response body. Would be good to have it parsed to `OBErrorResponse1`.

## Changes
- Extend existing ApiCallException class with two implementations: PaymentApiCallException and VrpApiCallException.
  New error classes may contain additional information about an error such as response code, Open Banking response error
  code and a bank error description.
- Upgrade com.diffplug.spotless to v6.8.0
- Upgrade com.github.spotbugs to v5.0.9

