### PR TITLE
[UKGRO-247] [Bugfix] make getFundsConfirmation for RestVrpClient a POST endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.0.1] - 2022-07-14
+## Changes
+- Make `getFundsConfirmation` function in `RestVrpClient` call the external endpoint with a `POST` method instead of `GET`
+  as it is a `POST` method according to [open banking standards](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/vrp/domestic-vrp-consents.html#post-domestic-vrp-consentsconsentidfunds-confirmation).
+
 ## [11.0.0] - 2022-07-05
 ## Changes
 - Extend existing `ApiCallException` class with two implementations: `PaymentApiCallException` and `VrpApiCallException`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=11.0.0
+version=11.0.1

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -115,7 +115,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         try {
             response = restOperations.exchange(
                 generateVrpApiUrl(FUNDS_CONFIRMATION_ENDPOINT_PATH_FORMAT, VRP_CONSENT_RESOURCE, aspspDetails),
-                HttpMethod.GET,
+                HttpMethod.POST,
                 request,
                 String.class,
                 consentId

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -233,7 +233,7 @@ class RestVrpClientTest {
         OBVRPFundsConfirmationResponse mockFundsConfirmationResponse = aFundsConfirmationResponse();
         String jsonResponse = jsonConverter.writeValueAsString(mockFundsConfirmationResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(DOMESTIC_VRP_CONSENTS_URL + "/" + consentId + "/funds-confirmation"))
-            .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-interaction-id", CoreMatchers.notNullValue()))
             .andExpect(MockRestRequestMatchers.header("x-fapi-financial-id", aspspDetails.getOrganisationId()))
@@ -264,7 +264,7 @@ class RestVrpClientTest {
             .thenReturn(accessTokenResponse);
 
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(DOMESTIC_VRP_CONSENTS_URL + "/" + consentId + "/funds-confirmation"))
-            .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withServerError());
 
         Assertions.assertThrows(VrpApiCallException.class,
@@ -290,7 +290,7 @@ class RestVrpClientTest {
 
         String jsonResponse = jsonConverter.writeValueAsString(response);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(DOMESTIC_VRP_CONSENTS_URL + "/" + consentId + "/funds-confirmation"))
-            .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
+            .andExpect(MockRestRequestMatchers.method(HttpMethod.POST))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
         Assertions.assertThrows(VrpApiCallException.class,


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a GitHub issue or other relevant documentation. -->
Make `getFundsConfirmation` function in `RestVrpClient` call the external endpoint with a `POST` method instead of `GET` as it is a `POST` method according to [open banking standards](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/vrp/domestic-vrp-consents.html#post-domestic-vrp-consentsconsentidfunds-confirmation)

## Changes

<!-- What changes have you made? Anything else we should keep in mind? -->
