### PR TITLE
[UKGRO-247] Fix headers for getFundsConfirmationRequest in VrpRestClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.1.0] - 2022-07-14
+## Changes
+- Fix headers for `POST` request sent via `RestVrpClient/getFundsConfirmation` to external endpoints. The header now uses
+access token provided by the client along with a detached JWS signature of the body of the payload. 
+
 ## [11.0.1] - 2022-07-14
 ## Changes
 - Make `getFundsConfirmation` function in `RestVrpClient` call the external endpoint with a `POST` method instead of `GET`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=11.0.1
+version=11.1.0

--- a/src/main/java/com/transferwise/openbanking/client/api/common/OpenBankingHeaders.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/common/OpenBankingHeaders.java
@@ -45,7 +45,7 @@ public class OpenBankingHeaders extends FapiHeaders {
      *
      * @param financialId    The ASPSP financial ID value to use as the x-fapi-financial-id header value
      * @param bearerToken    The bearer token to use for the Authorization header value
-     * @param idempotencyKey The idempotency key for the request, to use as the x-idempotency-key header value
+     * @param idempotencyKey The idempotency key for the request, to use as the x-idempotency-key header value. Can be null if no idempotency key is needed
      * @param jwsSignature   The JWS signature for the request, to use as the x-jws-signature header value
      * @return The built HTTP headers
      */
@@ -55,8 +55,10 @@ public class OpenBankingHeaders extends FapiHeaders {
                                                  String jwsSignature) {
         OpenBankingHeaders headers = defaultHeaders(financialId, bearerToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setIdempotencyKey(idempotencyKey);
         headers.setJwsSignature(jwsSignature);
+        if (idempotencyKey != null) {
+            headers.setIdempotencyKey(idempotencyKey);
+        }
         return headers;
     }
 

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -98,11 +98,15 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
     public OBVRPFundsConfirmationResponse getFundsConfirmation(
         String consentId,
         OBVRPFundsConfirmationRequest fundsConfirmationRequest,
-        AspspDetails aspspDetails
+        String accessToken,
+        AspspDetails aspspDetails,
+        SoftwareStatementDetails softwareStatementDetails
     ) {
-        OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(
+        OpenBankingHeaders headers = OpenBankingHeaders.postHeaders(
             aspspDetails.getOrganisationId(),
-            getClientCredentialsToken(aspspDetails)
+            accessToken,
+            null,
+            jwtClaimsSigner.createDetachedSignature(fundsConfirmationRequest, aspspDetails, softwareStatementDetails)
         );
 
         String body = jsonConverter.writeValueAsString(fundsConfirmationRequest);

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/VrpClient.java
@@ -61,7 +61,9 @@ public interface VrpClient {
      *
      * @param consentId                     The ID of the domestic VRP consent to get the details of
      * @param obVRPFundsConfirmationRequest The details of the VRP funds confirmation request
+     * @param accessToken                   The access token
      * @param aspspDetails                  The details of the ASPSP to send the request to
+     * @param softwareStatementDetails      The details of the software statement that the ASPSP registration uses
      * @return OBVRPFundsConfirmationResponse
      * @throws com.transferwise.openbanking.client.error.ClientException if there was a problem building the request(s)
      *                                                                   to the ASPSP or the HTTP call to the ASPSP
@@ -69,7 +71,9 @@ public interface VrpClient {
      */
     OBVRPFundsConfirmationResponse getFundsConfirmation(String consentId,
                                                         OBVRPFundsConfirmationRequest obVRPFundsConfirmationRequest,
-                                                        AspspDetails aspspDetails);
+                                                        String accessToken,
+                                                        AspspDetails aspspDetails,
+                                                        SoftwareStatementDetails softwareStatementDetails);
 
     /**
      * Retrieve a domestic VRP consent


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a GitHub issue or other relevant documentation. -->
Fix headers for getFundsConfirmationRequest in VrpRestClient

Earlier vs Now
headers 
1. Took client credentials as AUTH
2. JWS was not signed


Now
1. Takes access token provided by the client as AUTH
2. JWS is signed

Note - No idempotency header is needed for this POST request

Reference -[ link (look at the endpoints table)](https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/vrp/domestic-vrp-consents.html)

![Screenshot 2022-07-15 at 14 06 54](https://user-images.githubusercontent.com/15311127/179229914-b20dfab0-f161-4014-a23f-29600d8cd0e2.png)

## Changes

<!-- What changes have you made? Anything else we should keep in mind? -->
