### PR TITLE
[EUPAY-368] Fix  GetConsent failures when bank send Revoked status enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [12.0.1] - 2023-03-01
 ## Changes
-- Fix get consent failures when bank send Revoked status enum.
+- Fixed 'get consent failures when bank send Revoked status enum': OB VRP v3.1.9 specification doesn't specify Revoked state
+  for 'OBDomesticVRPConsentResponseData.StatusEnum' but some ASPSP still sends it. We fixed it by adding
+  VrpConsentResponseStatusEnumDeserializer which replace Revoked with Rejected while JSON deserializing.
 
 ## [12.0.0] - 2023-02-07
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [12.0.1] - 2023-03-01
 ## Changes
-- Fix get consent failures when bank send Revoked status enum.
+- Fixed 'get consent failures when bank send Revoked status enum': OB VRP v3.1.9 specification doesn't specify Revoked state
+  for 'OBDomesticVRPConsentResponseData.StatusEnum' but some ASPSP still sends it. We fixed it by adding
+  VrpConsentResponseStatusEnumDeserializer which replace Revoked with Rejected while JSON deserializing".
 
 ## [12.0.0] - 2023-02-07
 ## Changes
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [11.1.0] - 2022-07-14
 ## Changes
 - Fix headers for `POST` request sent via `RestVrpClient/getFundsConfirmation` to external endpoints. The header now uses
-access token provided by the client along with a detached JWS signature of the body of the payload. 
+access token provided by the client along with a detached JWS signature of the body of the payload.
 
 ## [11.0.1] - 2022-07-14
 ## Changes
@@ -24,7 +26,7 @@ access token provided by the client along with a detached JWS signature of the b
 ## [11.0.0] - 2022-07-05
 ## Changes
 - Extend existing `ApiCallException` class with two implementations: `PaymentApiCallException` and `VrpApiCallException`.
-  New error classes may contain additional information about an error such as response code, Open Banking response error 
+  New error classes may contain additional information about an error such as response code, Open Banking response error
   code and a bank error description.
 - Upgrade `com.diffplug.spotless` to `v6.8.0`
 - Upgrade `com.github.spotbugs` to `v5.0.9`
@@ -42,7 +44,7 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [8.0.2] - 2022-04-20
 ## Changes
-- Add debug logs to `RestVrpClient` 
+- Add debug logs to `RestVrpClient`
 
 ## [8.0.1] - 2022-04-20
 ## Changes
@@ -69,7 +71,7 @@ access token provided by the client along with a detached JWS signature of the b
 ## [7.2.2] - 2021-11-19
 ### Changed
 - Use client_credential for domestic Vrp initiation and funds confirmation flows.
- As both of them are not tied to the consent creation flow.      
+ As both of them are not tied to the consent creation flow.
 
 ## [7.2.1] - 2021-11-19
 ### Changed
@@ -77,7 +79,7 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [7.2.0] - 2021-11-12
 ### Added
-- Added `VrpClient` interface and its implementation which allows to create domestic VRP consent, 
+- Added `VrpClient` interface and its implementation which allows to create domestic VRP consent,
   confirm availability of funds for a VRP, retrieve and delete existing VRP consent. Also, it allows operations with a VRP like submit a domestic VRP and retrieve existing VRP.
 
 ## [7.1.0] - 2021-11-08
@@ -94,24 +96,24 @@ access token provided by the client along with a detached JWS signature of the b
 - Improvements to the Gradle publishing process
 
 ## [7.0.0] - 2021-07-13
-### Added 
+### Added
 - The `RegistrationClient` interface has a new method to call the delete client registration endpoint
 - The `GetAccessTokenRequest` class has new constructors to make it easier to supply the scope of the request
 ### Changed
 - The `RegistrationPermission` class has been renamed to `Scope` and moved to the `oauth.domain` package, to better
   correspond to what the class represents
-- Update the versions of various dependencies and plugins in the Gradle build configuration  
+- Update the versions of various dependencies and plugins in the Gradle build configuration
 
 ## [6.0.0] - 2021-05-18
 ### Added
-- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client 
-  registration requests, to allow easier customisation of this value per ASPSP. By default, 
+- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client
+  registration requests, to allow easier customisation of this value per ASPSP. By default,
   `getRegistrationTransportCertificateSubjectName` returns the certificate subject name in RFC 2253 format
 - The `AspspDetails` interface has a new method to return the scopes to request for an access token to use for an
-  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns 
+  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns
   the `openid` scope along with whatever scopes are configured for the software statement
 ### Changed
-- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new 
+- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new
   `getRegistrationAuthenticationScopes` method should be used instead to customise this behaviour
 - Change the type of the `OBSupplementaryData1` model from a string to an object, to prevent JSON de-serialization
   errors when parsing a JSON string with an empty object value (`{}`) for the supplementary data field.
@@ -119,23 +121,23 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [5.1.0] - 2021-05-17
 ### Changed
-- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the 
+- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the
   Jackson exception in a new `JsonReadException` class, and include the problematic JSON in the exception
-- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap 
-  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception  
-- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter` 
-  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this 
-  gives easy access to the full problematic JSON when  the response contains invalid JSON  
+- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap
+  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception
+- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter`
+  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this
+  gives easy access to the full problematic JSON when  the response contains invalid JSON
 
 ## [5.0.0] - 2021-04-20
 ### Added
-- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the 
+- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the
   `JacksonJsonConverter` implementing the interface
 ### Changed
-- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the 
+- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the
   `ObjectMapper` optional argument
 - The V3 `RestPaymentClient` class now requires a `JsonConverter` to be passed as a constructor argument. This is used
-  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance, 
+  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance,
   fixing an issue with null object fields being included in the serialised JSON request body
 - Update the versions of various dependencies and plugins in the Gradle build configuration
 
@@ -146,7 +148,7 @@ access token provided by the client along with a detached JWS signature of the b
 - Renamed the `getFinancialId` method on the `AspspDetails` interface to `getOrganisationId`, to better describe what
   it returns and how it is used
 - Renamed the `getRegistrationIssuerUrl` method on the `AspspDetails` interface to `getRegistrationAudience`,
-  to better describe what it returns and how it is used, and provide a more useful default implementation of returning 
+  to better describe what it returns and how it is used, and provide a more useful default implementation of returning
   the ASPSP organisation ID
 - Renamed the `getTokenIssuerUrl` method on the `AspspDetails` interface to `getPrivateKeyJwtAuthenticationAudience`,
   to better describe what it returns and how it is used, and provide a more useful default implementation of returning
@@ -168,51 +170,51 @@ access token provided by the client along with a detached JWS signature of the b
 - Change the `clientIdIssuedAt` and `clientSecretExpiresAt` fields in the `ClientRegistrationResponse` class from type
   `Integer` to type `String`, to handle ASPSPs that return timestamps in these fields instead of integers.
 - When requesting an access token for the update client registration API call, decide whether or not to include `openid`
-  in the scope parameter, based on the ASPSP integration details via the new 
+  in the scope parameter, based on the ASPSP integration details via the new
   `registrationAuthenticationRequiresOpenIdScope` method.
 
 ## [2.0.2] - 2021-02-01
 ### Changed
-- When requesting an access token for the update client registration API call, set the scope parameter to `payments`, 
+- When requesting an access token for the update client registration API call, set the scope parameter to `payments`,
   as certain ASPSPs require a scope value, not including `openid`, to be set .
 
 ## [2.0.1] - 2021-01-27
 ### Changed
-- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as 
-  certain ASPSPs require a scope value to be set. 
+- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as
+  certain ASPSPs require a scope value to be set.
 
 ## [2.0.0] - 2021-01-20
-### Added 
+### Added
 - The `RegistrationClient` interface has a new method to update an existing client registration with an ASPSP
-- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a 
+- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a
   registration request with multiple TPP redirect URLs, and the `PaymentClient` now supports multiple TPP redirect URLs
   when exchanging an authorization code as part of creating a domestic payment or checking funds availability
 ### Changed
 - The `ID_TOKEN` value in the `ResponseType` enum is replaced with `CODE_AND_ID_TOKEN`, so that the enum defines only
   the possible values required for the v3.2 client registration API, where it gets used for
-- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of 
-  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client 
+- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of
+  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client
   registration API
-- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`  
+- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`
 
 ## [1.0.1] - 2020-12-28
 ### Changed
-- Updated various dependencies to the latest versions, notably updating to Spring 5.3. 
+- Updated various dependencies to the latest versions, notably updating to Spring 5.3.
 
 ## [1.0.0] - 2020-12-20
 ### Added
 - A new `RegistrationRequestService` class which can build the request for client registration with an ASPSP
 ### Changed
-- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument, 
-  instead of the already signed claims, and does the signing itself 
+- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument,
+  instead of the already signed claims, and does the signing itself
 - The `registerClient` method in `RegistrationClient` now returns the registration response body as a data object with
   dedicated fields for the data, instead of a plain string
-- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport 
+- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport
   certificate to use for an ASPSP
-- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when 
+- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when
   registering as a client with an ASPSP
-- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for 
-  building a client registration request. 
+- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for
+  building a client registration request.
 
 ## [0.0.27] - 2020-12-18
 - Improvements to the Gradle publishing process
@@ -221,8 +223,8 @@ access token provided by the client along with a detached JWS signature of the b
 - Improvements to the Gradle publishing process
 
 ## [0.0.25] - 2020-12-03
-### Changed 
+### Changed
 - Prepare the library Gradle configuration for making the GitHub repository public.
 
 ## [0.0.24] - 2020-11-20
-- First version of the library published to a public Maven repository.  
+- First version of the library published to a public Maven repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.0.1] - 2023-03-01
+## Changes
+- Fix get consent failures when bank send Revoked status enum.
+
 ## [12.0.0] - 2023-02-07
 ## Changes
 - Added OpenBanking Event API support: `subscribeToAnEvent`, `getAllEventResources`, `changeAnEventResource`, `deleteAnEventResource`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [12.0.1] - 2023-03-01
 ## Changes
-- Fixed 'get consent failures when bank send Revoked status enum': OB VRP v3.1.9 specification doesn't specify Revoked state
-  for 'OBDomesticVRPConsentResponseData.StatusEnum' but some ASPSP still sends it. We fixed it by adding
-  VrpConsentResponseStatusEnumDeserializer which replace Revoked with Rejected while JSON deserializing".
+- Fix get consent failures when bank send Revoked status enum.
 
 ## [12.0.0] - 2023-02-07
 ## Changes
@@ -16,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [11.1.0] - 2022-07-14
 ## Changes
 - Fix headers for `POST` request sent via `RestVrpClient/getFundsConfirmation` to external endpoints. The header now uses
-access token provided by the client along with a detached JWS signature of the body of the payload.
+access token provided by the client along with a detached JWS signature of the body of the payload. 
 
 ## [11.0.1] - 2022-07-14
 ## Changes
@@ -26,7 +24,7 @@ access token provided by the client along with a detached JWS signature of the b
 ## [11.0.0] - 2022-07-05
 ## Changes
 - Extend existing `ApiCallException` class with two implementations: `PaymentApiCallException` and `VrpApiCallException`.
-  New error classes may contain additional information about an error such as response code, Open Banking response error
+  New error classes may contain additional information about an error such as response code, Open Banking response error 
   code and a bank error description.
 - Upgrade `com.diffplug.spotless` to `v6.8.0`
 - Upgrade `com.github.spotbugs` to `v5.0.9`
@@ -44,7 +42,7 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [8.0.2] - 2022-04-20
 ## Changes
-- Add debug logs to `RestVrpClient`
+- Add debug logs to `RestVrpClient` 
 
 ## [8.0.1] - 2022-04-20
 ## Changes
@@ -71,7 +69,7 @@ access token provided by the client along with a detached JWS signature of the b
 ## [7.2.2] - 2021-11-19
 ### Changed
 - Use client_credential for domestic Vrp initiation and funds confirmation flows.
- As both of them are not tied to the consent creation flow.
+ As both of them are not tied to the consent creation flow.      
 
 ## [7.2.1] - 2021-11-19
 ### Changed
@@ -79,7 +77,7 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [7.2.0] - 2021-11-12
 ### Added
-- Added `VrpClient` interface and its implementation which allows to create domestic VRP consent,
+- Added `VrpClient` interface and its implementation which allows to create domestic VRP consent, 
   confirm availability of funds for a VRP, retrieve and delete existing VRP consent. Also, it allows operations with a VRP like submit a domestic VRP and retrieve existing VRP.
 
 ## [7.1.0] - 2021-11-08
@@ -96,24 +94,24 @@ access token provided by the client along with a detached JWS signature of the b
 - Improvements to the Gradle publishing process
 
 ## [7.0.0] - 2021-07-13
-### Added
+### Added 
 - The `RegistrationClient` interface has a new method to call the delete client registration endpoint
 - The `GetAccessTokenRequest` class has new constructors to make it easier to supply the scope of the request
 ### Changed
 - The `RegistrationPermission` class has been renamed to `Scope` and moved to the `oauth.domain` package, to better
   correspond to what the class represents
-- Update the versions of various dependencies and plugins in the Gradle build configuration
+- Update the versions of various dependencies and plugins in the Gradle build configuration  
 
 ## [6.0.0] - 2021-05-18
 ### Added
-- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client
-  registration requests, to allow easier customisation of this value per ASPSP. By default,
+- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client 
+  registration requests, to allow easier customisation of this value per ASPSP. By default, 
   `getRegistrationTransportCertificateSubjectName` returns the certificate subject name in RFC 2253 format
 - The `AspspDetails` interface has a new method to return the scopes to request for an access token to use for an
-  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns
+  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns 
   the `openid` scope along with whatever scopes are configured for the software statement
 ### Changed
-- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new
+- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new 
   `getRegistrationAuthenticationScopes` method should be used instead to customise this behaviour
 - Change the type of the `OBSupplementaryData1` model from a string to an object, to prevent JSON de-serialization
   errors when parsing a JSON string with an empty object value (`{}`) for the supplementary data field.
@@ -121,23 +119,23 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [5.1.0] - 2021-05-17
 ### Changed
-- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the
+- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the 
   Jackson exception in a new `JsonReadException` class, and include the problematic JSON in the exception
-- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap
-  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception
-- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter`
-  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this
-  gives easy access to the full problematic JSON when  the response contains invalid JSON
+- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap 
+  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception  
+- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter` 
+  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this 
+  gives easy access to the full problematic JSON when  the response contains invalid JSON  
 
 ## [5.0.0] - 2021-04-20
 ### Added
-- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the
+- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the 
   `JacksonJsonConverter` implementing the interface
 ### Changed
-- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the
+- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the 
   `ObjectMapper` optional argument
 - The V3 `RestPaymentClient` class now requires a `JsonConverter` to be passed as a constructor argument. This is used
-  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance,
+  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance, 
   fixing an issue with null object fields being included in the serialised JSON request body
 - Update the versions of various dependencies and plugins in the Gradle build configuration
 
@@ -148,7 +146,7 @@ access token provided by the client along with a detached JWS signature of the b
 - Renamed the `getFinancialId` method on the `AspspDetails` interface to `getOrganisationId`, to better describe what
   it returns and how it is used
 - Renamed the `getRegistrationIssuerUrl` method on the `AspspDetails` interface to `getRegistrationAudience`,
-  to better describe what it returns and how it is used, and provide a more useful default implementation of returning
+  to better describe what it returns and how it is used, and provide a more useful default implementation of returning 
   the ASPSP organisation ID
 - Renamed the `getTokenIssuerUrl` method on the `AspspDetails` interface to `getPrivateKeyJwtAuthenticationAudience`,
   to better describe what it returns and how it is used, and provide a more useful default implementation of returning
@@ -170,51 +168,51 @@ access token provided by the client along with a detached JWS signature of the b
 - Change the `clientIdIssuedAt` and `clientSecretExpiresAt` fields in the `ClientRegistrationResponse` class from type
   `Integer` to type `String`, to handle ASPSPs that return timestamps in these fields instead of integers.
 - When requesting an access token for the update client registration API call, decide whether or not to include `openid`
-  in the scope parameter, based on the ASPSP integration details via the new
+  in the scope parameter, based on the ASPSP integration details via the new 
   `registrationAuthenticationRequiresOpenIdScope` method.
 
 ## [2.0.2] - 2021-02-01
 ### Changed
-- When requesting an access token for the update client registration API call, set the scope parameter to `payments`,
+- When requesting an access token for the update client registration API call, set the scope parameter to `payments`, 
   as certain ASPSPs require a scope value, not including `openid`, to be set .
 
 ## [2.0.1] - 2021-01-27
 ### Changed
-- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as
-  certain ASPSPs require a scope value to be set.
+- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as 
+  certain ASPSPs require a scope value to be set. 
 
 ## [2.0.0] - 2021-01-20
-### Added
+### Added 
 - The `RegistrationClient` interface has a new method to update an existing client registration with an ASPSP
-- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a
+- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a 
   registration request with multiple TPP redirect URLs, and the `PaymentClient` now supports multiple TPP redirect URLs
   when exchanging an authorization code as part of creating a domestic payment or checking funds availability
 ### Changed
 - The `ID_TOKEN` value in the `ResponseType` enum is replaced with `CODE_AND_ID_TOKEN`, so that the enum defines only
   the possible values required for the v3.2 client registration API, where it gets used for
-- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of
-  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client
+- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of 
+  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client 
   registration API
-- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`
+- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`  
 
 ## [1.0.1] - 2020-12-28
 ### Changed
-- Updated various dependencies to the latest versions, notably updating to Spring 5.3.
+- Updated various dependencies to the latest versions, notably updating to Spring 5.3. 
 
 ## [1.0.0] - 2020-12-20
 ### Added
 - A new `RegistrationRequestService` class which can build the request for client registration with an ASPSP
 ### Changed
-- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument,
-  instead of the already signed claims, and does the signing itself
+- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument, 
+  instead of the already signed claims, and does the signing itself 
 - The `registerClient` method in `RegistrationClient` now returns the registration response body as a data object with
   dedicated fields for the data, instead of a plain string
-- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport
+- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport 
   certificate to use for an ASPSP
-- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when
+- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when 
   registering as a client with an ASPSP
-- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for
-  building a client registration request.
+- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for 
+  building a client registration request. 
 
 ## [0.0.27] - 2020-12-18
 - Improvements to the Gradle publishing process
@@ -223,8 +221,8 @@ access token provided by the client along with a detached JWS signature of the b
 - Improvements to the Gradle publishing process
 
 ## [0.0.25] - 2020-12-03
-### Changed
+### Changed 
 - Prepare the library Gradle configuration for making the GitHub repository public.
 
 ## [0.0.24] - 2020-11-20
-- First version of the library published to a public Maven repository.
+- First version of the library published to a public Maven repository.  

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=12.0.0
+version=12.0.1

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -178,6 +178,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             response.getHeaders());
         OBDomesticVRPConsentResponse domesticVRPConsentResponse = jsonConverter.readValue(response.getBody(),
             OBDomesticVRPConsentResponse.class);
+
         validateResponse(domesticVRPConsentResponse);
         return domesticVRPConsentResponse;
     }
@@ -331,6 +332,7 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
 
         return domesticVrpDetailsResponse;
     }
+
     private void validateResponse(OBDomesticVRPConsentResponse response) {
         if (response == null
             || response.getData() == null

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -177,8 +177,8 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             response.getHeaders());
         OBDomesticVRPConsentResponse domesticVRPConsentResponse = jsonConverter.readValue(response.getBody(),
             OBDomesticVRPConsentResponse.class);
-
         validateResponse(domesticVRPConsentResponse);
+
         return domesticVRPConsentResponse;
     }
 

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -14,7 +14,6 @@ import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBVRPFundsCo
 import com.transferwise.openbanking.client.configuration.AspspDetails;
 import com.transferwise.openbanking.client.configuration.SoftwareStatementDetails;
 import com.transferwise.openbanking.client.json.JsonConverter;
-import com.transferwise.openbanking.client.json.JsonReadException;
 import com.transferwise.openbanking.client.jwt.JwtClaimsSigner;
 import com.transferwise.openbanking.client.oauth.OAuthClient;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -339,8 +339,8 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
             if (jsonString == null || !jsonString.contains("\"Status\":\"Revoked\"")) {
                 throw ex;
             }
-            jsonString = jsonString.replace("\"Status\":\"Revoked\"", "\"Status\":\"Rejected\"");
-            domesticVRPConsentResponse = jsonConverter.readValue(jsonString, OBDomesticVRPConsentResponse.class);
+            var replacedJsonString = jsonString.replace("\"Status\":\"Revoked\"", "\"Status\":\"Rejected\"");
+            domesticVRPConsentResponse = jsonConverter.readValue(replacedJsonString, OBDomesticVRPConsentResponse.class);
         }
         return domesticVRPConsentResponse;
     }

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -176,7 +176,8 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
 
         log.debug("method=getDomesticVrpConsentResponse code={} body={} headers={}", response.getStatusCode().value(), response.getBody(),
             response.getHeaders());
-        var domesticVRPConsentResponse = replaceRevokedStatusInDomesticVRPConsent(response.getBody());
+        OBDomesticVRPConsentResponse domesticVRPConsentResponse = jsonConverter.readValue(response.getBody(),
+            OBDomesticVRPConsentResponse.class);
         validateResponse(domesticVRPConsentResponse);
         return domesticVRPConsentResponse;
     }
@@ -330,21 +331,6 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
 
         return domesticVrpDetailsResponse;
     }
-
-    private OBDomesticVRPConsentResponse replaceRevokedStatusInDomesticVRPConsent(String jsonString) {
-        OBDomesticVRPConsentResponse domesticVRPConsentResponse;
-        try {
-            domesticVRPConsentResponse = jsonConverter.readValue(jsonString, OBDomesticVRPConsentResponse.class);
-        } catch (JsonReadException ex) {
-            if (jsonString == null || !jsonString.contains("\"Status\":\"Revoked\"")) {
-                throw ex;
-            }
-            var replacedJsonString = jsonString.replace("\"Status\":\"Revoked\"", "\"Status\":\"Rejected\"");
-            domesticVRPConsentResponse = jsonConverter.readValue(replacedJsonString, OBDomesticVRPConsentResponse.class);
-        }
-        return domesticVRPConsentResponse;
-    }
-
     private void validateResponse(OBDomesticVRPConsentResponse response) {
         if (response == null
             || response.getData() == null

--- a/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
@@ -22,11 +22,11 @@ public class JacksonJsonConverter implements JsonConverter {
 
     public JacksonJsonConverter() {
         objectMapper = new ObjectMapper();
-        SimpleModule module = new SimpleModule();
-        module.addDeserializer(
+        SimpleModule vrpConsentResponseStatusEnumModule = new SimpleModule();
+        vrpConsentResponseStatusEnumModule.addDeserializer(
             StatusEnum.class,
             new VrpConsentResponseStatusEnumDeserializer());
-        objectMapper.registerModule(module);
+        objectMapper.registerModule(vrpConsentResponseStatusEnumModule);
         objectMapper.registerModule(new Jdk8Module());
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/JacksonJsonConverter.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponseData.StatusEnum;
 
 /**
  * Implementation of the {@link JsonConverter} interface, using the Jackson library for JSON operations.
@@ -20,6 +22,11 @@ public class JacksonJsonConverter implements JsonConverter {
 
     public JacksonJsonConverter() {
         objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(
+            StatusEnum.class,
+            new VrpConsentResponseStatusEnumDeserializer());
+        objectMapper.registerModule(module);
         objectMapper.registerModule(new Jdk8Module());
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/src/main/java/com/transferwise/openbanking/client/json/VrpConsentResponseStatusEnumDeserializer.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/VrpConsentResponseStatusEnumDeserializer.java
@@ -1,0 +1,32 @@
+package com.transferwise.openbanking.client.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponseData.StatusEnum;
+import java.io.IOException;
+
+public class VrpConsentResponseStatusEnumDeserializer
+    extends StdDeserializer<StatusEnum> {
+
+    protected VrpConsentResponseStatusEnumDeserializer() {
+        this(null);
+    }
+
+    protected VrpConsentResponseStatusEnumDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public StatusEnum deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        String status = node.asText();
+        if ("Revoked".equals(status)) {
+            return StatusEnum.REJECTED;
+        }
+        return StatusEnum.fromValue(status);
+    }
+
+}

--- a/src/main/java/com/transferwise/openbanking/client/json/VrpConsentResponseStatusEnumDeserializer.java
+++ b/src/main/java/com/transferwise/openbanking/client/json/VrpConsentResponseStatusEnumDeserializer.java
@@ -7,8 +7,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponseData.StatusEnum;
 import java.io.IOException;
 
-public class VrpConsentResponseStatusEnumDeserializer
-    extends StdDeserializer<StatusEnum> {
+public class VrpConsentResponseStatusEnumDeserializer extends StdDeserializer<StatusEnum> {
 
     protected VrpConsentResponseStatusEnumDeserializer() {
         this(null);
@@ -19,8 +18,7 @@ public class VrpConsentResponseStatusEnumDeserializer
     }
 
     @Override
-    public StatusEnum deserialize(JsonParser jp, DeserializationContext ctxt)
-        throws IOException {
+    public StatusEnum deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         JsonNode node = jp.getCodec().readTree(jp);
         String status = node.asText();
         if ("Revoked".equals(status)) {
@@ -28,5 +26,4 @@ public class VrpConsentResponseStatusEnumDeserializer
         }
         return StatusEnum.fromValue(status);
     }
-
 }

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -351,7 +351,7 @@ class RestVrpClientTest {
             consentId,
             aspspDetails);
 
-        Assertions.assertEquals(actualDomesticVrpConsentResponse, expectedDomesticVrpConsentResponse);
+        Assertions.assertEquals(expectedDomesticVrpConsentResponse, actualDomesticVrpConsentResponse);
 
         Mockito.verify(jwtClaimsSigner, Mockito.never())
             .createDetachedSignature(Mockito.any(), Mockito.any(), Mockito.any());

--- a/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/vrp/RestVrpClientTest.java
@@ -11,6 +11,7 @@ import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVR
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentRequestData;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponse;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponseData;
+import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPConsentResponseData.StatusEnum;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPControlParameters;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPControlParametersPeriodicLimits;
 import com.transferwise.openbanking.client.api.payment.v3.model.vrp.OBDomesticVRPDetails;
@@ -322,8 +323,11 @@ class RestVrpClientTest {
         mockAspspServer.verify();
     }
 
-    @Test
-    void getDomesticVrpConsent() {
+    @ParameterizedTest
+    @ArgumentsSource(GetDomesticVrpConsentResponseArgumentProvider.class)
+    void getDomesticVrpConsent(
+        String jsonResponse,
+        OBDomesticVRPConsentResponse expectedDomesticVrpConsentResponse) {
         String consentId = "vrp-consent-id";
         AspspDetails aspspDetails = AspspDetailsFactory.aTestAspspDetails();
 
@@ -335,9 +339,6 @@ class RestVrpClientTest {
                         && "payments".equals(request.getRequestBody().get("scope"))),
                 Mockito.eq(aspspDetails)))
             .thenReturn(accessTokenResponse);
-
-        OBDomesticVRPConsentResponse mockDomesticVrpConsentResponse = aDomesticVrpConsentResponse();
-        String jsonResponse = jsonConverter.writeValueAsString(mockDomesticVrpConsentResponse);
         mockAspspServer.expect(MockRestRequestMatchers.requestTo(DOMESTIC_VRP_CONSENTS_URL + "/" + consentId))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessTokenResponse.getAccessToken()))
@@ -346,11 +347,11 @@ class RestVrpClientTest {
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        OBDomesticVRPConsentResponse domesticVrpConsentResponse = restVrpClient.getDomesticVrpConsent(
+        OBDomesticVRPConsentResponse actualDomesticVrpConsentResponse = restVrpClient.getDomesticVrpConsent(
             consentId,
             aspspDetails);
 
-        Assertions.assertEquals(mockDomesticVrpConsentResponse, domesticVrpConsentResponse);
+        Assertions.assertEquals(actualDomesticVrpConsentResponse, expectedDomesticVrpConsentResponse);
 
         Mockito.verify(jwtClaimsSigner, Mockito.never())
             .createDetachedSignature(Mockito.any(), Mockito.any(), Mockito.any());
@@ -834,6 +835,39 @@ class RestVrpClientTest {
             .paymentStatus(List.of(status));
         return new OBDomesticVRPDetails()
             .data(data);
+    }
+
+    private static class GetDomesticVrpConsentResponseArgumentProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            var mockDomesticVrpConsentAcceptResponse = getAcceptedResponse();
+            String jsonResponse = jsonConverter.writeValueAsString(
+                mockDomesticVrpConsentAcceptResponse);
+            return Stream.of(
+                Arguments.of(jsonResponse, mockDomesticVrpConsentAcceptResponse),
+                Arguments.of(
+                    jsonResponse.replace(
+                        "Authorised",
+                        "Revoked"),
+                    getRejectedResponse()));
+        }
+
+        private OBDomesticVRPConsentResponse getAcceptedResponse() {
+            OBDomesticVRPConsentResponseData acceptedData =
+                new OBDomesticVRPConsentResponseData()
+                    .consentId("vrp-consent-id")
+                    .status(StatusEnum.AUTHORISED);
+            return new OBDomesticVRPConsentResponse().data(acceptedData);
+        }
+
+        private OBDomesticVRPConsentResponse getRejectedResponse() {
+            OBDomesticVRPConsentResponseData rejectedData =
+                new OBDomesticVRPConsentResponseData()
+                    .consentId("vrp-consent-id")
+                    .status(StatusEnum.REJECTED);
+            return new OBDomesticVRPConsentResponse().data(rejectedData);
+        }
     }
 
     private static class PartialDomesticVrpConsentResponses implements ArgumentsProvider {


### PR DESCRIPTION
## Context

Openbaking doesn't support 'Revoked' StatusEnum from 3.1.8, but banks are still sending Revoked status.
This error should not impact customer and, we have decided to treat Revoked as Rejected. 

## Changes
1. The best way to handle this error is when the response is returned from bank. 
2. I am replacing Revoked string with rejected in response body. To avoid any unwanted changes, I am prefixing search string with status like “Status”:”Revoked”. 
3. Moved the above handling to separate function to have cleaner and follow single responsibility principle. 
4. I have explored other solutions like customizing JSON converter to handle not present enum but didn't find any. 


