### PR TITLE
[EUPAY-453] Adding  /event-notifications-openapi.yaml spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0] - 2023-03-08
+## Changes
+- Added spec https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml for OBEventNotification1, 
+required by client for receiving openbanking event notification from a bank.  
+
 ## [12.0.1] - 2023-03-01
 ## Changes
 - Fixed 'get consent failures when bank send Revoked status enum': OB VRP v3.1.9 specification doesn't specify Revoked state

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,15 @@ swaggerSources {
             configuration = configurations.openApiGen
         }
     }
+    eventNotifications {
+        inputFile = file('specs/event-notifications-openapi.yaml')
+        code {
+            language = 'java'
+            components = ['models']
+            configFile = file('specs/event-notifications-openapi.json')
+            configuration = configurations.openApiGen
+        }
+    }
 }
 
 compileJava.dependsOn(generateSwaggerCode)
@@ -112,10 +121,15 @@ compileJava.dependsOn(generateSwaggerCode)
 sourceSets.main.java.srcDir "${swaggerSources.paymentInitiation.code.outputDir}/src/main/java"
 sourceSets.main.java.srcDir "${swaggerSources.vrp.code.outputDir}/src/main/java"
 sourceSets.main.java.srcDir "${swaggerSources.event.code.outputDir}/src/main/java"
+sourceSets.main.java.srcDir "${swaggerSources.eventNotifications.code.outputDir}/src/main/java"
 
 spotless {
     java {
-        target layout.files("${swaggerSources.paymentInitiation.code.outputDir}/src/main/java","${swaggerSources.vrp.code.outputDir}/src/main/java", "${swaggerSources.event.code.outputDir}/src/main/java")
+        target layout.files(
+            "${swaggerSources.paymentInitiation.code.outputDir}/src/main/java",
+            "${swaggerSources.vrp.code.outputDir}/src/main/java",
+            "${swaggerSources.event.code.outputDir}/src/main/java",
+            "${swaggerSources.eventNotifications.code.outputDir}/src/main/java")
         replaceRegex 'Remove swagger @ApiModel annotations', '@ApiModel.*$', ''
         replaceRegex 'Remove swagger @ApiModelProperty annotations', '@ApiModelProperty.*$', ''
         replaceRegex 'Remove swagger @Schema annotations', '@Schema.*$', ''

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=12.0.1
+version=13.0.0

--- a/specs/event-notifications-openapi.json
+++ b/specs/event-notifications-openapi.json
@@ -1,0 +1,7 @@
+{
+  "library": "resttemplate",
+  "dateLibrary": "java8",
+  "serializableModel": "true",
+  "hideGenerationTimestamp": "true",
+  "modelPackage": "com.transferwise.openbanking.client.api.payment.v3.model.notifications"
+}

--- a/specs/event-notifications-openapi.yaml
+++ b/specs/event-notifications-openapi.yaml
@@ -1,0 +1,177 @@
+openapi: "3.0.0"
+info:
+    title: "Event Notification API Specification - TPP Endpoints"
+    description: "Swagger for Event Notification API Specification - TPP Endpoints"
+    termsOfService: "https://www.openbanking.org.uk/terms"
+    contact:
+        name: "Service Desk"
+        email: "ServiceDesk@openbanking.org.uk"
+    license:
+        name: "open-licence"
+        url: "https://www.openbanking.org.uk/open-licence"
+    version: "3.1.10"
+paths:
+    /event-notifications:
+        post:
+            summary: "Send an event notification"
+            operationId: "CreateEventNotification"
+            tags:
+                - "Event Notification"
+            parameters:
+                - $ref: "#/components/parameters/x-fapi-financial-id-Param"
+                - $ref: "#/components/parameters/x-fapi-interaction-id-Param"
+            requestBody:
+                content:
+                    application/jwt:
+                        schema:
+                            type: "string"
+                            format: "base64"
+                description: "Create an Callback URI"
+                required: true
+            responses:
+                202:
+                    description: "Accepted"
+servers:
+    - url: "/open-banking/v3.1"
+components:
+    parameters:
+        x-fapi-financial-id-Param:
+            in: "header"
+            name: "x-fapi-financial-id"
+            required: true
+            description: "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB."
+            schema:
+                type: "string"
+        x-fapi-interaction-id-Param:
+            in: "header"
+            name: "x-fapi-interaction-id"
+            required: false
+            description: "An RFC4122 UID used as a correlation id."
+            schema:
+                type: "string"
+    securitySchemes:
+        TPPOAuth2Security:
+            type: "oauth2"
+            description: "TPP client credential authorisation flow with the ASPSP"
+            flows:
+                clientCredentials:
+                    tokenUrl: "https://authserver.example/token"
+                    scopes:
+                        accounts: "Ability to read Accounts information"
+                        fundsconfirmations: "Ability to confirm funds"
+                        payments: "Generic payment scope"
+    schemas:
+        OBEvent1:
+            description: "Events."
+            type: "object"
+            properties:
+                urn:uk:org:openbanking:events:resource-update:
+                    $ref: "#/components/schemas/OBEventResourceUpdate1"
+            required:
+                - "urn:uk:org:openbanking:events:resource-update"
+            additionalProperties: false
+        OBEventLink1:
+            description: "Resource links to other available versions of the resource."
+            type: "object"
+            properties:
+                version:
+                    description: "Resource version."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 10
+                link:
+                    description: "Resource link."
+                    type: "string"
+            required:
+                - "version"
+                - "link"
+            additionalProperties: false
+            minProperties: 1
+        OBEventNotification1:
+            description: "The resource-update event."
+            type: "object"
+            properties:
+                iss:
+                    description: "Issuer."
+                    type: "string"
+                iat:
+                    description: "Issued At. "
+                    type: "integer"
+                    format: "int32"
+                    minimum: 0
+                jti:
+                    description: "JWT ID."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 128
+                aud:
+                    description: "Audience."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 128
+                sub:
+                    description: "Subject"
+                    type: "string"
+                    format: "uri"
+                txn:
+                    description: "Transaction Identifier."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 128
+                toe:
+                    description: "Time of Event."
+                    type: "integer"
+                    format: "int32"
+                    minimum: 0
+                events:
+                    $ref: "#/components/schemas/OBEvent1"
+            required:
+                - "iss"
+                - "iat"
+                - "jti"
+                - "aud"
+                - "sub"
+                - "txn"
+                - "toe"
+                - "events"
+            additionalProperties: false
+        OBEventResourceUpdate1:
+            description: "Resource-Update Event."
+            type: "object"
+            properties:
+                subject:
+                    $ref: "#/components/schemas/OBEventSubject1"
+            required:
+                - "subject"
+            additionalProperties: false
+        OBEventSubject1:
+            description: "The resource-update event."
+            type: "object"
+            properties:
+                subject_type:
+                    description: "Subject type for the updated resource. "
+                    type: "string"
+                    minLength: 1
+                    maxLength: 128
+                http://openbanking.org.uk/rid:
+                    description: "Resource Id for the updated resource."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 128
+                http://openbanking.org.uk/rty:
+                    description: "Resource Type for the updated resource."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 128
+                http://openbanking.org.uk/rlk:
+                    items:
+                        $ref: "#/components/schemas/OBEventLink1"
+                    type: "array"
+                    description: "Resource links to other available versions of the resource."
+                    minItems: 1
+            required:
+                - "subject_type"
+                - "http://openbanking.org.uk/rid"
+                - "http://openbanking.org.uk/rty"
+                - "http://openbanking.org.uk/rlk"
+            additionalProperties: false


### PR DESCRIPTION
## Context

To support of /event-notification callback in a client which will be called by bank to send VRP consent revocation notification. 
The payload class of Event Notification (OBEventNotification1)  is generated through this spec. 

I am putting this spec here as all other specs of open banking are here. 

Bumping version to 13.0.0 

## Changes

1. Added spec from https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml
2. Updated the build.gradle file to add swagger configuration for above spec. 
