### PR TITLE
[EUPAY-546] Renaming Event client APIs to reflect event subscription resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.0.0] - 2023-03-14
+## Changes
+- Renaming Event client APIs to reflect the event subscription resource. `subscribeToAnEvent` changed to `createEventSubscription`, 
+  `getAllEventResources` changed to `getEventSubscriptions`, `changeAnEventResource` changed to `changeEventSubscription`, `deleteAnEventResource` changed to `deleteEventSubscription`;
+
 ## [13.0.0] - 2023-03-08
 ## Changes
 - Added spec https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml for OBEventNotification1, 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=13.0.0
+version=14.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/event/EventClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/event/EventClient.java
@@ -24,7 +24,7 @@ public interface EventClient {
      * @return OBEventSubscriptionResponse1 The details of event subscribed.
      * @throws EventApiCallException    If subscribe API call to ASPSP fails
      */
-    OBEventSubscriptionResponse1 subscribeToAnEvent(
+    OBEventSubscriptionResponse1 createEventSubscription(
         OBEventSubscription1 eventSubscriptionRequest,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails);
@@ -36,7 +36,7 @@ public interface EventClient {
      * @return OBEventSubscriptionsResponse1    List of subscribed events.
      * @throws EventApiCallException    If get all events API call to ASPSP fails
      */
-    public OBEventSubscriptionsResponse1 getAllEventResources(AspspDetails aspspDetails);
+    public OBEventSubscriptionsResponse1 getEventSubscriptions(AspspDetails aspspDetails);
 
     /**
      * Change a subscribed event.
@@ -46,7 +46,7 @@ public interface EventClient {
      * @return OBEventSubscriptionResponse1 The details of the changed event resource.
      * @throws EventApiCallException    If change Event API call to ASPSP fails
      */
-    public OBEventSubscriptionResponse1 changeAnEventResource(
+    public OBEventSubscriptionResponse1 changeEventSubscription(
         OBEventSubscriptionResponse1 changedResponse,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails);
@@ -58,5 +58,5 @@ public interface EventClient {
      * @param aspspDetails  The details of the ASPSP.
      * @throws EventApiCallException    If delete event API call to ASPSP fails
      */
-    public void deleteAnEventResource(String eventSubscriptionId, AspspDetails aspspDetails);
+    public void deleteEventSubscription(String eventSubscriptionId, AspspDetails aspspDetails);
 }

--- a/src/main/java/com/transferwise/openbanking/client/api/event/RestEventClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/event/RestEventClient.java
@@ -40,7 +40,7 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
     }
 
     @Override
-    public OBEventSubscriptionResponse1 subscribeToAnEvent(
+    public OBEventSubscriptionResponse1 createEventSubscription(
         OBEventSubscription1 eventSubscriptionRequest,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails) {
@@ -75,7 +75,7 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
     }
 
     @Override
-    public OBEventSubscriptionsResponse1 getAllEventResources(AspspDetails aspspDetails)  {
+    public OBEventSubscriptionsResponse1 getEventSubscriptions(AspspDetails aspspDetails)  {
         OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(
             aspspDetails.getOrganisationId(),
             getClientCredentialsToken(aspspDetails)
@@ -109,7 +109,7 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
     }
 
     @Override
-    public OBEventSubscriptionResponse1 changeAnEventResource(
+    public OBEventSubscriptionResponse1 changeEventSubscription(
         OBEventSubscriptionResponse1 changedResponse,
         AspspDetails aspspDetails,
         SoftwareStatementDetails softwareStatementDetails) {
@@ -145,7 +145,7 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
 
 
     @Override
-    public void deleteAnEventResource(String eventSubscriptionId, AspspDetails aspspDetails) {
+    public void deleteEventSubscription(String eventSubscriptionId, AspspDetails aspspDetails) {
         OpenBankingHeaders headers = OpenBankingHeaders.defaultHeaders(
             aspspDetails.getOrganisationId(),
             getClientCredentialsToken(aspspDetails)

--- a/src/test/java/com/transferwise/openbanking/client/api/event/RestEventClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/event/RestEventClientTest.java
@@ -122,7 +122,7 @@ public class RestEventClientTest {
             .andRespond(
                 MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
 
-        var response = restEventClient.subscribeToAnEvent(eventSubscriptionRequest, aspspDetails, softwareStatementDetails);
+        var response = restEventClient.createEventSubscription(eventSubscriptionRequest, aspspDetails, softwareStatementDetails);
         Assertions.assertEquals(mockEventSubscriptionResponse, response);
         mockAspspServer.verify();
     }
@@ -139,7 +139,7 @@ public class RestEventClientTest {
             .andExpect(MockRestRequestMatchers.header(FINANCIAL_ID, aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
-        var response = restEventClient.getAllEventResources(aspspDetails);
+        var response = restEventClient.getEventSubscriptions(aspspDetails);
         Assertions.assertEquals(mockEventSubscriptionsResponse, response);
         mockAspspServer.verify();
     }
@@ -169,7 +169,7 @@ public class RestEventClientTest {
             .andExpect(MockRestRequestMatchers.header(JWS_SIGNATURE, DETACHED_JWS_SIGNATURE))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
-        var response = restEventClient.changeAnEventResource(eventSubscriptionOldResponse, aspspDetails, softwareStatementDetails);
+        var response = restEventClient.changeEventSubscription(eventSubscriptionOldResponse, aspspDetails, softwareStatementDetails);
         Assertions.assertEquals(mockEventSubscriptionResponse, response);
         mockAspspServer.verify();
     }
@@ -186,7 +186,7 @@ public class RestEventClientTest {
             .andExpect(MockRestRequestMatchers.header(FINANCIAL_ID, aspspDetails.getOrganisationId()))
             .andExpect(MockRestRequestMatchers.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
             .andRespond(MockRestResponseCreators.withSuccess(jsonResponse, MediaType.APPLICATION_JSON));
-        restEventClient.deleteAnEventResource(EVENT_SUBSCRIPTION_ID, aspspDetails);
+        restEventClient.deleteEventSubscription(EVENT_SUBSCRIPTION_ID, aspspDetails);
         mockAspspServer.verify();
     }
 


### PR DESCRIPTION
## Context

Renaming Event client APIs to reflect the event subscription resource:
Currently, the name informs that we are subscribing to just one event, but there can be multiple event in a request. 
Open banking spec these are called Event Subscription. 

## Changes

`subscribeToAnEvent` changed to `createEventSubscription`, 
  `getAllEventResources` changed to `getEventSubscriptions`, `changeAnEventResource` changed to `changeEventSubscription`, `deleteAnEventResource` changed to `deleteEventSubscription`
