### PR TITLE
[EUPAY-580] Updating event-notifications-openapi.yaml with OBEventConsentAuthorizationRevoked1 schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [14.0.1] - 2023-03-14
+## [15.0.0] - 2023-03-24
 ## Changes
-- Updating event-notifications-openapi.yaml spec: [openbanking spec](https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml)  doesn't contain OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 schemas.
+- Updated event-notifications-openapi.yaml spec: [openbanking spec](https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml)  doesn't contain OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 schemas.
 - Created our own custom schema for OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1.
-- OBExternalEventConsentAuthorizationRevokedReason1Code and OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code is not defined by OBIE till now, I have put string type until they define.
+- Updated OBEvent1 to OBEvent2, and added OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 in its properties. 
+- Updated OBEventNotification1 to OBEventNotification2, contains OBEvent2 as properties. 
+- OBExternalEventConsentAuthorizationRevokedReason1Code and OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code is not defined by OBIE till now, We have put string type until they define.
 
 ## [14.0.0] - 2023-03-14
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.0.1] - 2023-03-14
+## Changes
+- Updating event-notifications-openapi.yaml spec: [openbanking spec](https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml)  doesn't contain OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 schemas.
+- Created our own custom schema for OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1.
+- OBExternalEventConsentAuthorizationRevokedReason1Code and OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code is not defined by OBIE till now, I have put string type until they define.
+
 ## [14.0.0] - 2023-03-14
 ## Changes
 - Renaming Event client APIs to reflect the event subscription resource. `subscribeToAnEvent` changed to `createEventSubscription`, 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=14.0.0
+version=14.0.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=14.0.1
+version=15.0.0

--- a/specs/event-notifications-openapi.yaml
+++ b/specs/event-notifications-openapi.yaml
@@ -61,14 +61,16 @@ components:
                         fundsconfirmations: "Ability to confirm funds"
                         payments: "Generic payment scope"
     schemas:
-        OBEvent1:
+        OBEvent2:
             description: "Events."
             type: "object"
             properties:
-                urn:uk:org:openbanking:events:resource-update:
-                    $ref: "#/components/schemas/OBEventResourceUpdate1"
-            required:
-                - "urn:uk:org:openbanking:events:resource-update"
+                "urn:uk:org:openbanking:events:resource-update":
+                    $ref: "#/components/schemas/OBEventResourceUpdate2"
+                "urn:uk:org:openbanking:events:account-access-consent-linked-account-update":
+                    $ref: "#/components/schemas/OBEventAccountAccessConsentLinkedAccountUpdate1"
+                "urn:uk:org:openbanking:events:consent-authorization-revoked":
+                    $ref: "#/components/schemas/OBEventConsentAuthorizationRevoked1"
             additionalProperties: false
         OBEventLink1:
             description: "Resource links to other available versions of the resource."
@@ -87,7 +89,7 @@ components:
                 - "link"
             additionalProperties: false
             minProperties: 1
-        OBEventNotification1:
+        OBEventNotification2:
             description: "The resource-update event."
             type: "object"
             properties:
@@ -124,7 +126,7 @@ components:
                     format: "int32"
                     minimum: 0
                 events:
-                    $ref: "#/components/schemas/OBEvent1"
+                    $ref: "#/components/schemas/OBEvent2"
             required:
                 - "iss"
                 - "iat"
@@ -135,14 +137,44 @@ components:
                 - "toe"
                 - "events"
             additionalProperties: false
-        OBEventResourceUpdate1:
+        OBEventResourceUpdate2:
             description: "Resource-Update Event."
             type: "object"
             properties:
                 subject:
                     $ref: "#/components/schemas/OBEventSubject1"
+            additionalProperties: false
+        OBEventConsentAuthorizationRevoked1:
+            description: "An event that indicates a consent resource has had its authorisation revoked"
+            type: "object"
+            properties:
+                reason:
+                    $ref: "#/components/schemas/OBExternalEventConsentAuthorizationRevokedReason1Code"
+                subject:
+                    $ref: "#/components/schemas/OBEventSubject1"
+            additionalProperties: false
+        OBExternalEventConsentAuthorizationRevokedReason1Code:
+            description: "Reason for the Account Access Consent Linked Account Update event"
+            type: "string"
+            minLength: 1
+            maxLength: 128
+            additionalProperties: false
+        OBEventAccountAccessConsentLinkedAccountUpdate1:
+            description: "An event that indicates an account linked to a consent has move in/out of scope of the consent"
+            type: "object"
+            properties:
+                reason:
+                    $ref: "#/components/schemas/OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code"
+                subject:
+                    $ref: "#/components/schemas/OBEventSubject1"
             required:
                 - "subject"
+            additionalProperties: false
+        OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code:
+            description: "Reason for the Account Access Consent Linked Account Update event"
+            type: "string"
+            minLength: 1
+            maxLength: 128
             additionalProperties: false
         OBEventSubject1:
             description: "The resource-update event."


### PR DESCRIPTION


## Context

There is discrepancy in open banking event notification documentation https://openbankinguk.github.io/read-write-api-site3/v3.1.10/resources-and-data-models/event-notifications/event-notifications.html

They have used OBEventNotification1 as request body in some place and OBEventNotification2 some place else. 
Their spec https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml doesn't contains OBEventConsentAuthorizationRevoked1 & OBEventAccountAccessConsentLinkedAccountUpdate1 schema. 

I have searched google and people are customising spec if openbanking spec is not correct. 
Tested locally in PISP service.  Able to parse consent revoked notification. 

## Changes

- Created our own custom schema for OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1.
- OBExternalEventConsentAuthorizationRevokedReason1Code and OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code is not defined by OBIE till now, I have put string type until they define.

