### PR TITLE
[EUPAY-726]VRP Migration: From version 3.1.9 to 3.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [17.0.0] - 2023-05-26
+## Changes
+- VRP spec is updated to 3.1.10
+- Reference https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/vrp-openapi.yaml.
+
 ## [16.0.0] - 2023-05-19
 ## Changes
 - Payment initiation spec is updated to 3.1.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=16.0.0
+version=17.0.0

--- a/specs/vrp-openapi.yaml
+++ b/specs/vrp-openapi.yaml
@@ -6,7 +6,7 @@ servers:
 info:
   title: OBIE VRP Profile
   description: VRP OpenAPI Specification
-  version: 3.1.9
+  version: 3.1.10
   termsOfService: "https://www.openbanking.org.uk/terms"
   contact:
     name: "Service Desk"
@@ -49,6 +49,8 @@ paths:
           $ref: "#/components/responses/405Error"
         '406':
           $ref: "#/components/responses/406Error"
+        '409':
+          $ref: "#/components/responses/409Error"
         '415':
           $ref: "#/components/responses/415Error"
         '429':
@@ -172,6 +174,8 @@ paths:
         - $ref: "#/components/parameters/x-customer-user-agent"
 
       responses:
+        '200':
+          $ref: "#/components/responses/201OBDomesticVRPFundsConfirmationResponse"
         '201':
           $ref: "#/components/responses/201OBDomesticVRPFundsConfirmationResponse"
         '400':
@@ -237,6 +241,8 @@ paths:
           $ref: "#/components/responses/405Error"
         '406':
           $ref: "#/components/responses/406Error"
+        '409':
+          $ref: "#/components/responses/409Error"
         '415':
           $ref: "#/components/responses/415Error"
         '429':
@@ -420,6 +426,29 @@ components:
           required: true
           schema:
             type: "string"
+    409Error:
+      description: "Conflict"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
     415Error:
       description: "Unsupported Media Type"
       headers:
@@ -668,6 +697,7 @@ components:
             - "UK.OBIE.Unsupported.Frequency"
             - "UK.OBIE.Unsupported.LocalInstrument"
             - "UK.OBIE.Unsupported.Scheme"
+            - "UK.OBIE.Rules.ResourceAlreadyExists"
         Message:
           description: "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future'\nOBIE doesn't standardise this field"
           type: "string"


### PR DESCRIPTION
## Context

Santander have emailed to let us know they will not support versions  v3.1.9 of the Open Banking spec. Our current PISP version is based from v3.1.9.

## Changes

Picked up the 3.1.10 VRP spec from https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/vrp-openapi.yaml. 

We custom override: 
1. x-numerated-enum is changed to enum. 
2. double quote is added to Yes keyword. 

### Models changes assessment: 

https://transferwise.atlassian.net/wiki/spaces/EUP/pages/2893801433/Open+banking+VRP+Migration+Assessment+From+version+3.1.9+to+3.1.10 
