### PR TITLE
[EUPAY-727] Upgrading Java to 17 and gradle to 7.6

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [18.0.0] - 2023-10-26
+## Changes
+- Upgrading gradle version to 7.6
+- Upgrading java version to 17
+
 ## [17.0.0] - 2023-05-26
 ## Changes
 - VRP spec is updated to 3.1.10

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ apply from: 'build.publishing.gradle'
 
 group = 'com.transferwise'
 
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 ext {
     libs = [
@@ -197,7 +197,7 @@ tasks.withType(Pmd) {
 }
 
 wrapper {
-    gradleVersion = '7.0'
+    gradleVersion = '7.6'
 }
 
 test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=17.0.0
+version=18.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
+++ b/src/main/java/com/transferwise/openbanking/client/configuration/AspspDetails.java
@@ -235,8 +235,7 @@ public interface AspspDetails {
      * Whether or not the ASPSP expects detached message signatures to use the Open Banking directory format for the 'http://openbanking.org.uk/iss'
      * claim, i.e. '{{org-id}}/{{software-statement-id}}', or to use the signing certificate subject value.
      *
-     * @return <code>true</code> if the detached signature should use the Open Banking directory format for the ISS claim,
-     * <code>false</code> otherwise
+     * @return <code>true</code> if the detached signature should use the Open Banking directory format for the ISS claim,<code>false</code> otherwise
      */
     default boolean detachedSignatureUsesDirectoryIssFormat() {
         return true;

--- a/src/test/java/com/transferwise/openbanking/client/api/event/RestEventClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/event/RestEventClientTest.java
@@ -42,7 +42,7 @@ import org.springframework.web.client.RestTemplate;
     "checkstyle:membername",
     "checkstyle:methodname",
     "checkstyle:abbreviationaswordinname"})
-public class RestEventClientTest {
+class RestEventClientTest {
 
     private static final String EVENT_SUBSCRIPTION_URL = "https://aspsp.co.uk/open-banking/v3.1/event-subscriptions";
     private static final String CALLBACK_URL = "callback-url";


### PR DESCRIPTION
## Context

Java version not updated for long time and official Java version is also 17
It makes difficult for developer to build on old version. 

## Changes
1. Update Java version to 17. 
2. Gradle to 7.6 as 7.0 was not compatible to Java 17. 
3. Some checkstyle and test was failing due to syntax change in new Java. Fixed those. 
