### PR TITLE
EUPAY-957: Move openbanking-client to Spring Web 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [19.0.0] - 2023-10-30
+## Changes
+- Upgrading Spring Web to 6
+- Upgrading Jackson to 2.15
+
 ## [18.0.0] - 2023-10-26
 ## Changes
 - Upgrading gradle version to 7.6
@@ -22,19 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changes
 - Updated event-notifications-openapi.yaml spec: [openbanking spec](https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml)  doesn't contain OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 schemas.
 - Created our own custom schema for OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1.
-- Updated OBEvent1 to OBEvent2, and added OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 in its properties. 
-- Updated OBEventNotification1 to OBEventNotification2, contains OBEvent2 as properties. 
+- Updated OBEvent1 to OBEvent2, and added OBEventConsentAuthorizationRevoked1 and OBEventAccountAccessConsentLinkedAccountUpdate1 in its properties.
+- Updated OBEventNotification1 to OBEventNotification2, contains OBEvent2 as properties.
 - OBExternalEventConsentAuthorizationRevokedReason1Code and OBExternalEventAccountAccessConsentLinkedAccountUpdateReason1Code is not defined by OBIE till now, We have put string type until they define.
 
 ## [14.0.0] - 2023-03-14
 ## Changes
-- Renaming Event client APIs to reflect the event subscription resource. `subscribeToAnEvent` changed to `createEventSubscription`, 
+- Renaming Event client APIs to reflect the event subscription resource. `subscribeToAnEvent` changed to `createEventSubscription`,
   `getAllEventResources` changed to `getEventSubscriptions`, `changeAnEventResource` changed to `changeEventSubscription`, `deleteAnEventResource` changed to `deleteEventSubscription`;
 
 ## [13.0.0] - 2023-03-08
 ## Changes
-- Added spec https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml for OBEventNotification1, 
-required by client for receiving openbanking event notification from a bank.  
+- Added spec https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/event-notifications-openapi.yaml for OBEventNotification1,
+required by client for receiving openbanking event notification from a bank.
 
 ## [12.0.1] - 2023-03-01
 ## Changes
@@ -49,7 +54,7 @@ required by client for receiving openbanking event notification from a bank.
 ## [11.1.0] - 2022-07-14
 ## Changes
 - Fix headers for `POST` request sent via `RestVrpClient/getFundsConfirmation` to external endpoints. The header now uses
-access token provided by the client along with a detached JWS signature of the body of the payload. 
+access token provided by the client along with a detached JWS signature of the body of the payload.
 
 ## [11.0.1] - 2022-07-14
 ## Changes
@@ -59,7 +64,7 @@ access token provided by the client along with a detached JWS signature of the b
 ## [11.0.0] - 2022-07-05
 ## Changes
 - Extend existing `ApiCallException` class with two implementations: `PaymentApiCallException` and `VrpApiCallException`.
-  New error classes may contain additional information about an error such as response code, Open Banking response error 
+  New error classes may contain additional information about an error such as response code, Open Banking response error
   code and a bank error description.
 - Upgrade `com.diffplug.spotless` to `v6.8.0`
 - Upgrade `com.github.spotbugs` to `v5.0.9`
@@ -77,7 +82,7 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [8.0.2] - 2022-04-20
 ## Changes
-- Add debug logs to `RestVrpClient` 
+- Add debug logs to `RestVrpClient`
 
 ## [8.0.1] - 2022-04-20
 ## Changes
@@ -104,7 +109,7 @@ access token provided by the client along with a detached JWS signature of the b
 ## [7.2.2] - 2021-11-19
 ### Changed
 - Use client_credential for domestic Vrp initiation and funds confirmation flows.
- As both of them are not tied to the consent creation flow.      
+ As both of them are not tied to the consent creation flow.
 
 ## [7.2.1] - 2021-11-19
 ### Changed
@@ -112,7 +117,7 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [7.2.0] - 2021-11-12
 ### Added
-- Added `VrpClient` interface and its implementation which allows to create domestic VRP consent, 
+- Added `VrpClient` interface and its implementation which allows to create domestic VRP consent,
   confirm availability of funds for a VRP, retrieve and delete existing VRP consent. Also, it allows operations with a VRP like submit a domestic VRP and retrieve existing VRP.
 
 ## [7.1.0] - 2021-11-08
@@ -129,24 +134,24 @@ access token provided by the client along with a detached JWS signature of the b
 - Improvements to the Gradle publishing process
 
 ## [7.0.0] - 2021-07-13
-### Added 
+### Added
 - The `RegistrationClient` interface has a new method to call the delete client registration endpoint
 - The `GetAccessTokenRequest` class has new constructors to make it easier to supply the scope of the request
 ### Changed
 - The `RegistrationPermission` class has been renamed to `Scope` and moved to the `oauth.domain` package, to better
   correspond to what the class represents
-- Update the versions of various dependencies and plugins in the Gradle build configuration  
+- Update the versions of various dependencies and plugins in the Gradle build configuration
 
 ## [6.0.0] - 2021-05-18
 ### Added
-- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client 
-  registration requests, to allow easier customisation of this value per ASPSP. By default, 
+- The `AspspDetails` interface has a new method to return the transport certificate subject name, for use in client
+  registration requests, to allow easier customisation of this value per ASPSP. By default,
   `getRegistrationTransportCertificateSubjectName` returns the certificate subject name in RFC 2253 format
 - The `AspspDetails` interface has a new method to return the scopes to request for an access token to use for an
-  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns 
+  authenticated call to the ASPSP's update registration API. By default, `getRegistrationAuthenticationScopes` returns
   the `openid` scope along with whatever scopes are configured for the software statement
 ### Changed
-- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new 
+- The `registrationAuthenticationRequiresOpenIdScope` method on the `AspspDetails` interface has been removed, the new
   `getRegistrationAuthenticationScopes` method should be used instead to customise this behaviour
 - Change the type of the `OBSupplementaryData1` model from a string to an object, to prevent JSON de-serialization
   errors when parsing a JSON string with an empty object value (`{}`) for the supplementary data field.
@@ -154,23 +159,23 @@ access token provided by the client along with a detached JWS signature of the b
 
 ## [5.1.0] - 2021-05-17
 ### Changed
-- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the 
+- When a JSON processing error is encountered when de-serializing JSON in the `JacksonJsonConverter` class, wrap the
   Jackson exception in a new `JsonReadException` class, and include the problematic JSON in the exception
-- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap 
-  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception  
-- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter` 
-  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this 
-  gives easy access to the full problematic JSON when  the response contains invalid JSON  
+- When a JSON processing error is encountered when serializing JSON an object in the `JacksonJsonConverter` class, wrap
+  the Jackson exception in a new `JsonWriteException` class, and include the problematic object in the exception
+- In the `RestPaymentClient` class, do the API call response de-serialization ourselves rather via the `JsonConverter`
+  functionality, rather than having the Spring `RestTemplate` functionality do it. Coupled with the above change, this
+  gives easy access to the full problematic JSON when  the response contains invalid JSON
 
 ## [5.0.0] - 2021-04-20
 ### Added
-- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the 
+- A new `JsonConverter` interface has been added, which deals with converting to and from JSON, with the
   `JacksonJsonConverter` implementing the interface
 ### Changed
-- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the 
+- The `JwtSigner` class now requires a `JsonConverter` to passed as a constructor argument. This replaces the
   `ObjectMapper` optional argument
 - The V3 `RestPaymentClient` class now requires a `JsonConverter` to be passed as a constructor argument. This is used
-  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance, 
+  to create the JSON request bodies explicitly rather than it being done internally by the `RestOperations` instance,
   fixing an issue with null object fields being included in the serialised JSON request body
 - Update the versions of various dependencies and plugins in the Gradle build configuration
 
@@ -181,7 +186,7 @@ access token provided by the client along with a detached JWS signature of the b
 - Renamed the `getFinancialId` method on the `AspspDetails` interface to `getOrganisationId`, to better describe what
   it returns and how it is used
 - Renamed the `getRegistrationIssuerUrl` method on the `AspspDetails` interface to `getRegistrationAudience`,
-  to better describe what it returns and how it is used, and provide a more useful default implementation of returning 
+  to better describe what it returns and how it is used, and provide a more useful default implementation of returning
   the ASPSP organisation ID
 - Renamed the `getTokenIssuerUrl` method on the `AspspDetails` interface to `getPrivateKeyJwtAuthenticationAudience`,
   to better describe what it returns and how it is used, and provide a more useful default implementation of returning
@@ -203,51 +208,51 @@ access token provided by the client along with a detached JWS signature of the b
 - Change the `clientIdIssuedAt` and `clientSecretExpiresAt` fields in the `ClientRegistrationResponse` class from type
   `Integer` to type `String`, to handle ASPSPs that return timestamps in these fields instead of integers.
 - When requesting an access token for the update client registration API call, decide whether or not to include `openid`
-  in the scope parameter, based on the ASPSP integration details via the new 
+  in the scope parameter, based on the ASPSP integration details via the new
   `registrationAuthenticationRequiresOpenIdScope` method.
 
 ## [2.0.2] - 2021-02-01
 ### Changed
-- When requesting an access token for the update client registration API call, set the scope parameter to `payments`, 
+- When requesting an access token for the update client registration API call, set the scope parameter to `payments`,
   as certain ASPSPs require a scope value, not including `openid`, to be set .
 
 ## [2.0.1] - 2021-01-27
 ### Changed
-- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as 
-  certain ASPSPs require a scope value to be set. 
+- When requesting an access token for the update client registration API call, set the scope parameter to `openid`, as
+  certain ASPSPs require a scope value to be set.
 
 ## [2.0.0] - 2021-01-20
-### Added 
+### Added
 - The `RegistrationClient` interface has a new method to update an existing client registration with an ASPSP
-- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a 
+- There is now support for multiple TPP redirect URLs, the `RegistrationRequestService` now supports generating a
   registration request with multiple TPP redirect URLs, and the `PaymentClient` now supports multiple TPP redirect URLs
   when exchanging an authorization code as part of creating a domestic payment or checking funds availability
 ### Changed
 - The `ID_TOKEN` value in the `ResponseType` enum is replaced with `CODE_AND_ID_TOKEN`, so that the enum defines only
   the possible values required for the v3.2 client registration API, where it gets used for
-- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of 
-  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client 
+- The `AspspDetails` interface method `getResponseTypes` now returns only `CODE_AND_ID_TOKEN` by default, instead of
+  the separate `CODE` and `ID_TOKEN` values, to align the default value with the defaults of the v3.2 client
   registration API
-- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`  
+- The `TppConfiguration` class string field `redirectUrl` is replaced with a list of strings field `redirectUrls`
 
 ## [1.0.1] - 2020-12-28
 ### Changed
-- Updated various dependencies to the latest versions, notably updating to Spring 5.3. 
+- Updated various dependencies to the latest versions, notably updating to Spring 5.3.
 
 ## [1.0.0] - 2020-12-20
 ### Added
 - A new `RegistrationRequestService` class which can build the request for client registration with an ASPSP
 ### Changed
-- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument, 
-  instead of the already signed claims, and does the signing itself 
+- The `registerClient` method in `RegistrationClient` now takes the unsigned registration claims as an argument,
+  instead of the already signed claims, and does the signing itself
 - The `registerClient` method in `RegistrationClient` now returns the registration response body as a data object with
   dedicated fields for the data, instead of a plain string
-- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport 
+- The `KeySupplier` interface has been moved to the `security` package and has a new method to get the transport
   certificate to use for an ASPSP
-- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when 
+- The `TppConfiguration` class has a new property, for the permissions that the TPP has and wants to request when
   registering as a client with an ASPSP
-- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for 
-  building a client registration request. 
+- The `AspspDetails` interface has new methods to describe additional integration details with the ASPSP, required for
+  building a client registration request.
 
 ## [0.0.27] - 2020-12-18
 - Improvements to the Gradle publishing process
@@ -256,8 +261,8 @@ access token provided by the client along with a detached JWS signature of the b
 - Improvements to the Gradle publishing process
 
 ## [0.0.25] - 2020-12-03
-### Changed 
+### Changed
 - Prepare the library Gradle configuration for making the GitHub repository public.
 
 ## [0.0.24] - 2020-11-20
-- First version of the library published to a public Maven repository.  
+- First version of the library published to a public Maven repository.

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ targetCompatibility = JavaVersion.VERSION_17
 
 ext {
     libs = [
-        'spring': '5.3.6',
-        'jackson': '2.12.3',
+        'spring': '6.0.13',
+        'jackson': '2.15.2',
         'lombok': '1.18.20',
         'junit': '5.7.1',
         'mockito': '3.9.0'
@@ -61,19 +61,14 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:${libs.lombok}")
     testAnnotationProcessor("org.projectlombok:lombok:${libs.lombok}")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:${libs.junit}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${libs.junit}")
-
+    testImplementation("org.junit.jupiter:junit-jupiter:${libs.junit}")
     testImplementation("org.mockito:mockito-core:${libs.mockito}")
     testImplementation("org.mockito:mockito-junit-jupiter:${libs.mockito}")
-
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("org.skyscreamer:jsonassert:1.5.1")
-
     testImplementation("org.springframework:spring-test:${libs.spring}")
-
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")
-
     testImplementation("ch.qos.logback:logback-classic:1.4.5")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=18.0.0
+version=19.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/event/RestEventClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/event/RestEventClient.java
@@ -100,7 +100,7 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
         }
 
         if (response.getStatusCode().is4xxClientError() || response.getStatusCode().is5xxServerError()) {
-            throw new EventApiCallException("Call to get event resource endpoint failed. Status code " + response.getStatusCode().name());
+            throw new EventApiCallException("Call to get event resource endpoint failed. Status code " + response.getStatusCode().value());
         }
         OBEventSubscriptionsResponse1 eventSubscriptionResponse = jsonConverter.readValue(
             response.getBody(),
@@ -171,7 +171,7 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
         if (response.getStatusCode().is4xxClientError() || response.getStatusCode().is5xxServerError()) {
             throw new EventApiCallException(
                 "Call to delete event subscription endpoint failed. Status code "
-                    + response.getStatusCode().name());
+                    + response.getStatusCode().value());
         }
     }
 

--- a/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/vrp/RestVrpClient.java
@@ -376,10 +376,10 @@ public class RestVrpClient extends BasePaymentClient implements VrpClient {
         }
         if (response.getStatusCode().is4xxClientError()
             || response.getStatusCode().is5xxServerError()) {
-            throw new VrpApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().name());
+            throw new VrpApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().value());
         }
         log.info("Call to delete VRP consent endpoint failed with unexpected status code {}", response.getStatusCode().value());
-        throw new VrpApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().name());
+        throw new VrpApiCallException("Call to delete VRP consent endpoint failed. Status code " + response.getStatusCode().value());
     }
 
     private OBErrorResponse1 mapBodyToObErrorResponse(String responseBodyAsString) {


### PR DESCRIPTION
## Context

Going forward we want openbanking-client to support Spring Boot 3.  To do this we need to make use of Spring Web 6 which is the current version of Spring within Spring Boot 3. 

## Changes

This brings in the latest version of Spring Web (and Jackson) and makes a small modification to the code to support the new interfaces. 

Going forward, this library will not support earlier versions of Spring Web 
