### PR TITLE
[EUPAY-1033] VRP Spec Upgrade: From version 3.1.1 to 3.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [20.0.0] - 2023-12-18
+## Changes
+- VRP spec is upgraded to 3.1.11
+
 ## [19.0.0] - 2023-10-30
 ## Changes
 - Upgrading Spring Web to 6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=19.0.0
+version=20.0.0

--- a/specs/vrp-openapi.yaml
+++ b/specs/vrp-openapi.yaml
@@ -174,8 +174,6 @@ paths:
         - $ref: "#/components/parameters/x-customer-user-agent"
 
       responses:
-        '200':
-          $ref: "#/components/responses/201OBDomesticVRPFundsConfirmationResponse"
         '201':
           $ref: "#/components/responses/201OBDomesticVRPFundsConfirmationResponse"
         '400':

--- a/specs/vrp-openapi.yaml
+++ b/specs/vrp-openapi.yaml
@@ -6,7 +6,7 @@ servers:
 info:
   title: OBIE VRP Profile
   description: VRP OpenAPI Specification
-  version: 3.1.10
+  version: 3.1.11
   termsOfService: "https://www.openbanking.org.uk/terms"
   contact:
     name: "Service Desk"
@@ -1034,6 +1034,7 @@ components:
           required:
             - ConsentId
             - PSUAuthenticationMethod
+            - VRPType
             - Initiation
             - Instruction
           properties:
@@ -1051,6 +1052,8 @@ components:
               allOf:
                 - $ref: '#/components/schemas/OBVRPInteractionTypes'
                 - description: The interaction style used.
+            VRPType:
+                $ref: '#/components/schemas/OBVRPConsentType'
             Initiation:
               $ref: '#/components/schemas/OBDomesticVRPInitiation'
             Instruction:
@@ -1076,6 +1079,7 @@ components:
             - StatusUpdateDateTime
             - Initiation
             - Instruction
+            - DebtorAccount
           properties:
             DomesticVRPId:
               type: string
@@ -1435,6 +1439,7 @@ components:
         - UK.OBIE.PAN
         - UK.OBIE.Paym
         - UK.OBIE.SortCodeAccountNumber
+        - UK.OBIE.Wallet
 
     OBExternalFinancialInstitutionIdentification4Code:
       description: |-


### PR DESCRIPTION
## Context

Mandatory,  spec upgrade is required by HSBC, otherwise we won't be able to provide HSBC integration in openbanking. 



## Changes

Picked up the 3.1.11 VRP spec from https://github.com/OpenBankingUK/read-write-api-specs/blob/master/dist/openapi/vrp-openapi.yaml.

**Custom override:**

x-numerated-enum is changed to enum.
double quote is added to Yes keyword.
allOf: which do validation, is not removed. 

All changes, without customisation, can be seen here: https://github.com/transferwise/openbanking-client/pull/225/files?diff=split&w=1 
