### PR TITLE
[EUPAY-1439]: bump library version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [21.0.0] - 2023-12-18
+## Changes
+- Replace `RestTemplate` with `WebClient`
+
 ## [20.0.0] - 2023-12-18
 ## Changes
 - VRP spec is upgraded to 3.1.11

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=20.0.0
+version=21.0.0

--- a/src/main/java/com/transferwise/openbanking/client/api/event/RestEventClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/event/RestEventClient.java
@@ -61,16 +61,15 @@ public class RestEventClient extends BasePaymentClient implements EventClient {
 
         String body = jsonConverter.writeValueAsString(eventSubscriptionRequest);
         HttpEntity<String> request = new HttpEntity<>(body, headers);
-        var response = webClient.post()
+        return webClient.post()
             .uri(generateEventApiUrl(BASE_ENDPOINT_PATH_FORMAT, EVENT_SUBSCRIPTION_RESOURCE, aspspDetails))
             .headers(httpHeaders -> httpHeaders.addAll(request.getHeaders()))
             .bodyValue(Validate.notNull(request.getBody()))
             .retrieve()
-            .bodyToMono(String.class)
+            .bodyToMono(OBEventSubscriptionResponse1.class)
             .onErrorResume(WebClientResponseException.class, e -> handleWebClientResponseException(e, ON_ERROR_SUB_EVENT_LOG))
             .onErrorResume(WebClientException.class, e -> handleWebClientException(e, ON_ERROR_SUB_EVENT_LOG, EventApiCallException.class))
             .block();
-        return jsonConverter.readValue(response, OBEventSubscriptionResponse1.class);
     }
 
     @Override

--- a/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClient.java
@@ -37,7 +37,7 @@ import wiremock.org.apache.commons.lang3.Validate;
 @RequiredArgsConstructor
 @Slf4j
 @SuppressWarnings("checkstyle:membername")
-public class AsyncRegistrationClient implements RegistrationClient {
+public class RestRegistrationClient implements RegistrationClient {
 
     private final JwtClaimsSigner jwtClaimsSigner;
     private final OAuthClient oAuthClient;

--- a/src/main/java/com/transferwise/openbanking/client/oauth/RestOAuthClient.java
+++ b/src/main/java/com/transferwise/openbanking/client/oauth/RestOAuthClient.java
@@ -27,7 +27,7 @@ import wiremock.org.apache.commons.lang3.Validate;
 
 @RequiredArgsConstructor
 @Slf4j
-public class AsyncOAuthClient implements OAuthClient {
+public class RestOAuthClient implements OAuthClient {
 
     private final ClientAuthentication clientAuthentication;
     private final WebClient webClient;

--- a/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/api/registration/RestRegistrationClientTest.java
@@ -59,7 +59,7 @@ import org.springframework.web.reactive.function.client.WebClient;
     "checkstyle:membername",
     "checkstyle:variabledeclarationusagedistance",
     "checkstyle:methodname"})
-class AsyncRegistrationClientTest {
+class RestRegistrationClientTest {
 
     private static ObjectMapper objectMapper;
 
@@ -69,7 +69,7 @@ class AsyncRegistrationClientTest {
     @Mock
     private OAuthClient oAuthClient;
 
-    private AsyncRegistrationClient asyncRegistrationClient;
+    private RestRegistrationClient restRegistrationClient;
 
     private WireMockServer wireMockServer;
 
@@ -86,7 +86,7 @@ class AsyncRegistrationClientTest {
 
         WebClient webClient = WebClient.create("http://localhost:" + wireMockServer.port());
 
-        asyncRegistrationClient = new AsyncRegistrationClient(jwtClaimsSigner, oAuthClient, webClient);
+        restRegistrationClient = new RestRegistrationClient(jwtClaimsSigner, oAuthClient, webClient);
     }
 
     @AfterEach
@@ -116,7 +116,7 @@ class AsyncRegistrationClientTest {
             .withRequestBody(equalTo(signedClaims))
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
-        ClientRegistrationResponse registrationResponse = asyncRegistrationClient.registerClient(
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.registerClient(
             clientRegistrationRequest,
             aspspDetails);
 
@@ -140,7 +140,7 @@ class AsyncRegistrationClientTest {
         WireMock.stubFor(post(urlEqualTo(aspspDetails.getRegistrationUrl()))
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
-        ClientRegistrationResponse registrationResponse = asyncRegistrationClient.registerClient(
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.registerClient(
             clientRegistrationRequest,
             aspspDetails);
 
@@ -163,7 +163,7 @@ class AsyncRegistrationClientTest {
         WireMock.stubFor(post(urlEqualTo(aspspDetails.getRegistrationUrl())).willReturn(serverError()));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> asyncRegistrationClient.registerClient(clientRegistrationRequest, aspspDetails));
+            () -> restRegistrationClient.registerClient(clientRegistrationRequest, aspspDetails));
 
         WireMock.verify(exactly(1), postRequestedFor(urlEqualTo(aspspDetails.getRegistrationUrl())));
     }
@@ -201,7 +201,7 @@ class AsyncRegistrationClientTest {
             .withRequestBody(equalTo(signedClaims))
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
-        ClientRegistrationResponse registrationResponse = asyncRegistrationClient.updateRegistration(
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
             clientRegistrationRequest,
             aspspDetails,
             softwareStatementDetails);
@@ -239,7 +239,7 @@ class AsyncRegistrationClientTest {
             .withHeader(HttpHeaders.CONTENT_TYPE, equalTo(expectedContentType))
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
-        ClientRegistrationResponse registrationResponse = asyncRegistrationClient.updateRegistration(
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
             clientRegistrationRequest,
             aspspDetails,
             softwareStatementDetails);
@@ -281,7 +281,7 @@ class AsyncRegistrationClientTest {
         WireMock.stubFor(put(urlEqualTo(aspspDetails.getRegistrationUrl() + "/client-id"))
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
-        ClientRegistrationResponse registrationResponse = asyncRegistrationClient.updateRegistration(
+        ClientRegistrationResponse registrationResponse = restRegistrationClient.updateRegistration(
             clientRegistrationRequest,
             aspspDetails,
             softwareStatementDetails);
@@ -310,7 +310,7 @@ class AsyncRegistrationClientTest {
         WireMock.stubFor(put(urlEqualTo(aspspDetails.getRegistrationUrl() + "/client-id")).willReturn(serverError()));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> asyncRegistrationClient.updateRegistration(
+            () -> restRegistrationClient.updateRegistration(
                 clientRegistrationRequest,
                 aspspDetails,
                 softwareStatementDetails));
@@ -341,7 +341,7 @@ class AsyncRegistrationClientTest {
             .withHeader(HttpHeaders.AUTHORIZATION, equalTo("Bearer access-token"))
             .willReturn(status(200)));
 
-        asyncRegistrationClient.deleteRegistration(aspspDetails, softwareStatementDetails);
+        restRegistrationClient.deleteRegistration(aspspDetails, softwareStatementDetails);
 
         WireMock.verify(exactly(1), deleteRequestedFor(urlEqualTo(aspspDetails.getRegistrationUrl() + "/client-id")));
     }
@@ -361,7 +361,7 @@ class AsyncRegistrationClientTest {
             .willReturn(serverError()));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> asyncRegistrationClient.deleteRegistration(aspspDetails, softwareStatementDetails));
+            () -> restRegistrationClient.deleteRegistration(aspspDetails, softwareStatementDetails));
 
         WireMock.verify(exactly(1), deleteRequestedFor(urlEqualTo(aspspDetails.getRegistrationUrl() + "/client-id")));
     }

--- a/src/test/java/com/transferwise/openbanking/client/oauth/RestOAuthClientTest.java
+++ b/src/test/java/com/transferwise/openbanking/client/oauth/RestOAuthClientTest.java
@@ -40,14 +40,14 @@ import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @ExtendWith(MockitoExtension.class)
-class AsyncOAuthClientTest {
+class RestOAuthClientTest {
 
     private static ObjectMapper objectMapper;
 
     @Mock
     private ClientAuthentication clientAuthentication;
 
-    private AsyncOAuthClient asyncOAuthClient;
+    private RestOAuthClient restOAuthClient;
 
     private WireMockServer wireMockServer;
 
@@ -63,7 +63,7 @@ class AsyncOAuthClientTest {
         WireMock.configureFor("localhost", wireMockServer.port());
         WebClient webClient = WebClient.create("http://localhost:" + wireMockServer.port());
 
-        asyncOAuthClient = new AsyncOAuthClient(clientAuthentication, webClient);
+        restOAuthClient = new RestOAuthClient(clientAuthentication, webClient);
     }
 
     @AfterEach
@@ -90,7 +90,7 @@ class AsyncOAuthClientTest {
             .withRequestBody(equalTo(expectedBody))
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
-        AccessTokenResponse accessTokenResponse = asyncOAuthClient.getAccessToken(getAccessTokenRequest,
+        AccessTokenResponse accessTokenResponse = restOAuthClient.getAccessToken(getAccessTokenRequest,
             aspspDetails);
 
         Assertions.assertEquals(mockAccessTokenResponse, accessTokenResponse);
@@ -108,7 +108,7 @@ class AsyncOAuthClientTest {
         WireMock.stubFor(post(urlEqualTo(aspspDetails.getTokenUrl())).willReturn(serverError()));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> asyncOAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails));
+            () -> restOAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails));
 
         WireMock.verify(exactly(1), postRequestedFor(urlEqualTo(aspspDetails.getTokenUrl())));
     }
@@ -127,7 +127,7 @@ class AsyncOAuthClientTest {
             .willReturn(okForContentType(APPLICATION_JSON_VALUE, jsonResponse)));
 
         Assertions.assertThrows(ApiCallException.class,
-            () -> asyncOAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails));
+            () -> restOAuthClient.getAccessToken(getAccessTokenRequest, aspspDetails));
 
         WireMock.verify(exactly(1), postRequestedFor(urlEqualTo(aspspDetails.getTokenUrl())));
     }


### PR DESCRIPTION
## Context

This is the final PR to migrate openbanking-client to use `WebClient` from `RestTemplate`. This PR bumps the library version to `21.0.0`

Changes to return `Mono` type so that the client can use `.block()` by themselves will be separated into another version.


<!-- Why is this PR necessary? If available, include links to a GitHub issue or other relevant documentation. -->

## Changes

- Bump library version to `21.0.0`
- Rename `Async` back to `Rest`

<!-- What changes have you made? Anything else we should keep in mind? -->
